### PR TITLE
fix build:dev error

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "body-parser": "1.18.2",
-    "chronoshift": "0.6.8",
+    "chronoshift": "0.6.9",
     "clipboard": "1.7.1",
     "compression": "1.7.1",
     "d3": "3.5.17",


### PR DESCRIPTION
Argument of type '{ timezone: Timezone; }' is not assignable to parameter of type 'Environment'

![image](https://user-images.githubusercontent.com/571878/39912447-54dca36a-5531-11e8-8fa2-1bfd269761dd.png)
