### PR TITLE
Fixed dimensions drag and drop behaviour in Firefox

### DIFF
--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -84,8 +84,9 @@ export class DimensionListTile extends React.Component<DimensionListTileProps, D
   }
 
   dragStart(dimension: Dimension, e: DragEvent) {
-    var dataTransfer = e.dataTransfer;
+    const dataTransfer = e.dataTransfer;
     dataTransfer.effectAllowed = 'all';
+    dataTransfer.setData('text/plain', dimension.title);
 
     DragManager.setDragDimension(dimension, 'dimension-list-tile');
     setDragGhost(dataTransfer, dimension.title);

--- a/src/client/components/dimension-tile/dimension-tile.tsx
+++ b/src/client/components/dimension-tile/dimension-tile.tsx
@@ -376,6 +376,7 @@ export class DimensionTile extends React.Component<DimensionTileProps, Dimension
 
     const dataTransfer = e.dataTransfer;
     dataTransfer.effectAllowed = 'all';
+    dataTransfer.setData('text/plain', dimension.title);
 
     DragManager.setDragDimension(dimension, 'dimension-tile');
     setDragGhost(dataTransfer, dimension.title);

--- a/src/client/components/filter-tile/filter-tile.tsx
+++ b/src/client/components/filter-tile/filter-tile.tsx
@@ -226,6 +226,7 @@ export class FilterTile extends React.Component<FilterTileProps, FilterTileState
   dragStart(dimension: Dimension, clause: FilterClause, e: DragEvent) {
     const dataTransfer = e.dataTransfer;
     dataTransfer.effectAllowed = 'all';
+    dataTransfer.setData('text/plain', dimension.title);
 
     DragManager.setDragDimension(dimension, 'filter-tile');
 

--- a/src/client/components/split-tile/split-tile.tsx
+++ b/src/client/components/split-tile/split-tile.tsx
@@ -167,8 +167,9 @@ export class SplitTile extends React.Component<SplitTileProps, SplitTileState> {
   }
 
   dragStart(dimension: Dimension, split: SplitCombine, splitIndex: number, e: DragEvent) {
-    var dataTransfer = e.dataTransfer;
+    const dataTransfer = e.dataTransfer;
     dataTransfer.effectAllowed = 'all';
+    dataTransfer.setData('text/plain', dimension.title);
 
     DragManager.setDragSplit(split, 'filter-tile');
     DragManager.setDragDimension(dimension, 'filter-tile');


### PR DESCRIPTION
Fixes #118

Historically DataTransfer's data was being set to URLs of a data cube with additional split based on dragged dimension. It did not make sense as dimensions are not always dragged to split tile.

In one of the latest PRs we have stopped setting DataTransfer's data. However it occurs that Firefox requires any data to be set on DataTransfer object to start handling a drag and drop at all.

With this PR DataTransfer's data will be set with dimension's title in dragStart event handlers to satisfy Firefox requirements.