### PR TITLE
Dimension and measure groups

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,9 @@
 /test/
 /typings/
 *.js.map
+*.fixtures.js
 *.mocha.js
+*.mock.js
 *.ts
 *.tgz
 *.iml

--- a/config-examples.yaml
+++ b/config-examples.yaml
@@ -10,7 +10,8 @@ dataCubes:
       time: 2015-09-13T00:00:00.000Z
 
     defaultDuration: P1D
-    defaultSortMeasure: delta
+    defaultSortMeasure: added
+    defaultSelectedMeasures: ["added"]
 
     defaultPinnedDimensions: ["channel","namespace","isRobot"]
     introspection: no-autofill
@@ -38,19 +39,27 @@ dataCubes:
         title: City Name
         formula: $cityName
 
-      - name: comment
-        title: Comment
-        formula: $comment
+      - name: comments
+        title: Comments
+        dimensions:
 
-      - name: commentLength
-        title: Comment Length
-        kind: number
-        formula: $commentLength
+          - name: comment
+            title: Comment
+            formula: $comment
 
-      - name: commentLengthOver100
-        title: Comment Length Over 100
-        kind: boolean
-        formula: $commentLength > 100
+          - name: commentLengths
+            title: Comment Lengths
+            dimensions:
+
+              - name: commentLength
+                title: Comment Length
+                kind: number
+                formula: $commentLength
+
+              - name: commentLengthOver100
+                title: Comment Length Over 100
+                kind: boolean
+                formula: $commentLength > 100
 
       - name: countryIso
         title: Country ISO
@@ -118,17 +127,25 @@ dataCubes:
         formula: $userChars
 
     measures:
-      - name: count
-        title: Rows
-        formula: $main.count()
+      - name: rowsAndDeltas
+        title: Rows & Deltas
+        measures:
 
-      - name: delta
-        title: Delta
-        formula: $main.sum($delta)
+          - name: count
+            title: Rows
+            formula: $main.count()
 
-      - name: avg_delta
-        title: Avg Delta
-        formula: $main.average($delta)
+          - name: deltas
+            title: Deltas
+            measures:
+
+              - name: delta
+                title: Delta
+                formula: $main.sum($delta)
+
+              - name: avg_delta
+                title: Avg Delta
+                formula: $main.average($delta)
 
       - name: added
         title: Added

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -27,7 +27,8 @@ module.exports = {
     path: path.resolve(__dirname, '../build/public'),
     filename: "main.js",
     chunkFilename: "[name].[hash].js",
-    publicPath: '/'
+    publicPath: '/',
+    pathinfo: false
   },
   devtool: "source-map",
   resolve: {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,14 +271,21 @@ You can now use `$age` in numeric expressions. For example you could create a di
 ### Dimensions
 
 In this section you can define the dimensions that users can *split* and *filter* on in the UI.
+Dimensions may be organized as list or tree where each item of list can be either a dimension
+or [dimension group](#dimension-group) having its own dimensions list or tree.
 The order of the dimension list in the top of the left panel is determined by the order of the dimensions definitions
 in this section.
+
+
+#### Dimension
+
+Dimensions are defined with following attributes:
 
 **name** (string)
 
 The name of the dimension.
 This does not have to correspond to the attribute name (but the auto generated dimensions do).
-This should be a URL safe string.
+This should be a URL safe string and unique across dimensions, dimension groups, measures and measure groups.
 Changing this property will break any URLs that someone might have generated that include this dimension.
 
 **title** (string)
@@ -318,7 +325,7 @@ You can create derived dimensions by using non-trivial formulas.
 
 Here are some common use cases for derived dimensions:
 
-#### Lookup formula
+##### Lookup formula
 
 If you have a dimension that represents an ID that is a key into some other table. You may have set up a
 [Druid Query Time Lookup](http://druid.io/docs/latest/querying/lookups.html) in which case you could
@@ -335,7 +342,7 @@ You can also apply the `.fallback()` action as ether:
 - `$lookupKey.lookup('my_awesome_lookup').fallback($lookupKey)` to keep values that were not found as they are.
 - `$lookupKey.lookup('my_awesome_lookup').fallback('missing')` to map missing values to the word 'missing'.
 
-#### Extraction formula
+##### Extraction formula
 
 Imagine you have an attribute `resourceName` which has values:
 
@@ -356,7 +363,7 @@ Which would have values:
 ["0.8.2", "0.8.1", "0.7.0", null]
 ```
 
-#### Boolean formula
+##### Boolean formula
 
 It is often useful to create dimensions that are the result of some boolean expression.
 Let's say that you are responsible for all accounts in the United States as well as some specific account you could create a dimension like:
@@ -368,7 +375,7 @@ Let's say that you are responsible for all accounts in the United States as well
 
 Now my account would represent a custom filter boolean diemension.
 
-#### Custom transformations
+##### Custom transformations
 
 If no existing plywood function meets your needs, you could also define your own custom transformation.
 The transformation could be any supported [Druid extraction function](http://druid.io/docs/latest/querying/dimensionspecs.html).
@@ -394,11 +401,34 @@ Then in the dimensions simply reference `stringFun` like so:
   formula: $countryURL.customTransform('stringFun')
 ```
 
+#### Dimension Group
+
+Dimension groups are defined with following attributes:
+
+**name** (string)
+
+The name of the dimension group.
+This should be a URL safe string and unique across dimensions, dimension groups, measures and measure groups.
+
+**title** (string)
+
+The title for this dimension group in the UI. Can be anything and is safe to change at any time.
+
+**dimensions** (Dimension | DimensionGroup)[]
+
+An array of nested dimensions or dimension groups. It cannot be empty.
+
 ### Measures
 
 In this section you can define the measures that users can *aggregate* on (*apply*) on in the UI.
+Measures may be organized as list or tree where each item of list can be either a measure
+or [measure group](#measure-group) having its own measures list or tree.
 The order of the measure list in the bottom of the left panel is determined by the order of the measure definitions
 in this section.
+
+#### Measure
+
+Measures are defined with following attributes:
 
 **name** (string)
 
@@ -432,7 +462,7 @@ Predefined transformation that can be applied to a measure formula. Currently su
 One can also create derived measures by using non-trivial expressions in **formula**. Here are some common use cases for derived dimensions:
 
 
-#### Ratio formula
+##### Ratio formula
 
 Ratios are generally considered fun.
 
@@ -443,7 +473,7 @@ Ratios are generally considered fun.
 ```
 
 
-#### Filtered aggregations formula
+##### Filtered aggregations formula
 
 A very powerful tool is to use a filtered aggregate.
 If, for example, your revenue in the US is a very important measure you could express it as:
@@ -462,7 +492,7 @@ It is also common to express a ratio of something filtered vs unfiltered.
 ```
 
 
-#### Custom aggregations
+##### Custom aggregations
 
 Within the measures you have access to the full power of the [Plywood expressions](http://plywood.imply.io/expressions).
 If you ever find yourself needing to go beyond the expressive potential of Plywood you could define your own custom aggregation.
@@ -496,7 +526,7 @@ Then in the measures simply reference `addedMod1337` like so:
 This functionality can be used to access any custom aggregations that might be loaded via extensions.
 
 
-#### Switching metric columns
+##### Switching metric columns
 
 If you switch how you ingest you underlying metric and can't (or do not want to) recalculate all of the previous data,
 you could use a derived measure to seemly merge these two metrics in the UI.
@@ -558,6 +588,25 @@ Then in the measure definitions:
 ```
 
 Note that whichever method you chose you should not change the `name` attribute of your original measure as it will preserve the function of any bookmarks.
+
+
+#### Measure Group
+
+Measure groups are defined with following attributes:
+
+**name** (string)
+
+The name of the measure group.
+This should be a URL safe string and unique across dimensions, dimension groups, measures and measure groups.
+
+**title** (string)
+
+The title for this measure group in the UI. Can be anything and is safe to change at any time.
+
+**measures** (Measure | MeasureGroup)[]
+
+An array of nested measures or measure groups. It cannot be empty.
+
 
 ## Customization
 

--- a/src/client/components/dimension-list-tile/dimension-item.tsx
+++ b/src/client/components/dimension-list-tile/dimension-item.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { DragEvent, MouseEvent } from "react";
+import { DragEvent, MouseEvent, PureComponent } from "react";
 import { HighlightString, SvgIcon } from "..";
 import { classNames } from "../../utils/dom/dom";
 
@@ -34,7 +34,7 @@ export interface DimensionItemProps {
 export type DimensionClickHandler = (dimensionName: string, e: MouseEvent<HTMLElement>) => void;
 export type DimensionDragStartHandler = (dimensionName: string, e: DragEvent<HTMLElement>) => void;
 
-export class DimensionItem extends React.PureComponent<DimensionItemProps, {}> {
+export class DimensionItem extends PureComponent<DimensionItemProps, {}> {
   handleClick = (e: MouseEvent<HTMLElement>) => {
     const { name, dimensionClick } = this.props;
     dimensionClick(name, e);

--- a/src/client/components/dimension-list-tile/dimension-item.tsx
+++ b/src/client/components/dimension-list-tile/dimension-item.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { DragEvent, MouseEvent } from "react";
+import { HighlightString, SvgIcon } from "..";
+import { classNames } from "../../utils/dom/dom";
+
+export const DIMENSION_CLASS_NAME = 'dimension';
+
+export interface DimensionItemProps {
+  name: string;
+  title: string;
+  classSuffix: string;
+  dimensionClick: DimensionClickHandler;
+  dimensionDragStart: DimensionDragStartHandler;
+  searchText: string;
+  selected: boolean;
+}
+
+export type DimensionClickHandler = (dimensionName: string, e: MouseEvent<HTMLElement>) => void;
+export type DimensionDragStartHandler = (dimensionName: string, e: DragEvent<HTMLElement>) => void;
+
+export class DimensionItem extends React.PureComponent<DimensionItemProps, {}> {
+  handleClick = (e: MouseEvent<HTMLElement>) => {
+    const { name, dimensionClick } = this.props;
+    dimensionClick(name, e);
+  }
+
+  handleDragStart = (e: DragEvent<HTMLElement>) => {
+    const { name, dimensionDragStart } = this.props;
+    dimensionDragStart(name, e);
+  }
+
+  render() {
+    const { name, title, classSuffix, searchText, selected } = this.props;
+
+    const className = classNames(
+      DIMENSION_CLASS_NAME,
+      'type-' + classSuffix,
+      {
+        selected
+      }
+    );
+
+    return <div
+      className={className}
+      key={name}
+      onClick={this.handleClick}
+      draggable={true}
+      onDragStart={this.handleDragStart}
+    >
+      <div className="icon">
+        <SvgIcon svg={require('../../icons/dim-' + classSuffix + '.svg')} />
+      </div>
+      <HighlightString className={classNames("label")} text={title} highlight={searchText} />
+
+    </div>;
+  }
+
+}

--- a/src/client/components/dimension-list-tile/dimension-list-tile.scss
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.scss
@@ -22,27 +22,30 @@ $icon-width: 37px;
 .dimension-list-tile {
   overflow: hidden;
 
-  .items {
-    position: absolute;
+  .rows {
     top: $title-height;
-    bottom: 0;
-    width: 100%;
-    overflow: auto;
-    color: $text-standard;
-    transition: height 0.1s ease-in-out;
+
+    .folder {
+      .dimension {
+        &:last-child {
+          margin-bottom: $searchable-folder-last-child-margin;
+        }
+      }
+    }
 
     .dimension {
-      @include pin-top($dimension-height);
       background: $white;
       cursor: pointer;
       overflow: hidden;
-      transition: transform 0.1s ease-in-out;
+      padding-left: 14px;
+      height: $dimension-height;
+      //transition: transform 0.1s ease-in-out;
 
       &:last-child {
-        margin-bottom: 12px;
+        margin-bottom: $searchable-tile-last-child-margin;
       }
 
-      &.highlight {
+      &:hover {
         background: $hover;
       }
 
@@ -51,14 +54,12 @@ $icon-width: 37px;
       }
 
       .icon {
-        @include pin-left($icon-width);
         top: 4px;
-        left: 0;
+        left: -2px;
         width: 19px;
+        float: left;
 
         svg {
-          position: absolute;
-          left: $padding-compact - 2px;
           width: 19px;
 
           path {
@@ -67,13 +68,10 @@ $icon-width: 37px;
         }
       }
 
-      .item-title {
+      .label {
         @include ellipsis;
-        position: absolute;
-        top: 7px;
-        bottom: 0;
-        right: 10px;
-        left: $icon-width + 1;
+        display: block;
+        padding: 7px 0.15em;
       }
     }
   }

--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -161,7 +161,8 @@ export class DimensionListTile extends Component<DimensionListTileProps, Dimensi
     const { searchText } = this.state;
 
     if (!!searchText && !dimensionsForView.some(dimension => dimension.hasSearchText)) {
-      return <div className="message">{`No ${ STRINGS.dimensions.toLowerCase() } for "${searchText}"`}</div>;
+      const noDimensionsFound = `No dimensions for "${searchText}"`;
+      return <div className="message">{noDimensionsFound}</div>;
     } else {
       return <></>;
     }

--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -17,7 +17,7 @@
 
 import * as React from "react";
 import { DragEvent, MouseEvent } from "react";
-import { Clicker, Dimension, Essence, Stage } from '../../../common/models/index';
+import { Clicker, DataCube, Dimension, Essence, Filter, Splits, Stage } from '../../../common/models/index';
 import { Fn } from '../../../common/utils/general/general';
 import { MAX_SEARCH_LENGTH, STRINGS } from '../../config/constants';
 import { findParentWithClass, setDragGhost } from '../../utils/dom/dom';
@@ -52,10 +52,21 @@ const hasSearchTextPredicate = (searchText: string) => (dimension: Dimension): b
 
 const isFilteredOrSplitPredicate = (essence: Essence) => (dimension: Dimension): boolean => {
   const { dataCube, filter, splits } = essence;
-  const filteredDimensions = filter.clauses.map((clause) => dataCube.dimensions.getDimensionByExpression(clause.expression));
-  const splitDimensions = splits.splitCombines.map((split) => dataCube.dimensions.getDimensionByExpression(split.expression));
+  return isFiltered(dimension, filter, dataCube) || isSplit(dimension, splits, dataCube);
+};
 
-  return filteredDimensions.contains(dimension) || splitDimensions.contains(dimension);
+const isSplit = (dimension: Dimension, splits: Splits, dataCube: DataCube): boolean => {
+  return splits
+    .splitCombines
+    .map((split) => dataCube.dimensions.getDimensionByExpression(split.expression))
+    .contains(dimension);
+};
+
+const isFiltered = (dimension: Dimension, filter: Filter, dataCube: DataCube): boolean => {
+  return filter
+    .clauses
+    .map((clause) => dataCube.dimensions.getDimensionByExpression(clause.expression))
+    .contains(dimension);
 };
 
 export class DimensionListTile extends React.Component<DimensionListTileProps, DimensionListTileState> {

--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from "react";
-import { DragEvent, MouseEvent } from "react";
+import { Component, CSSProperties, DragEvent, MouseEvent } from "react";
 import { Clicker, DataCube, Dimension, Essence, Filter, Splits, Stage } from '../../../common/models/index';
 import { Fn } from '../../../common/utils/general/general';
 import { MAX_SEARCH_LENGTH, STRINGS } from '../../config/constants';
@@ -30,13 +30,13 @@ import './dimension-list-tile.scss';
 import { DimensionOrGroupForView, DimensionsConverter } from "./dimensions-converter";
 import { DimensionsRenderer } from "./dimensions-renderer";
 
-export interface DimensionListTileProps extends React.Props<any> {
+export interface DimensionListTileProps {
   clicker: Clicker;
   essence: Essence;
   menuStage: Stage;
   triggerFilterMenu: Fn;
   triggerSplitMenu: Fn;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 }
 
 export interface DimensionListTileState {
@@ -69,7 +69,7 @@ const isFiltered = (dimension: Dimension, filter: Filter, dataCube: DataCube): b
     .contains(dimension);
 };
 
-export class DimensionListTile extends React.Component<DimensionListTileProps, DimensionListTileState> {
+export class DimensionListTile extends Component<DimensionListTileProps, DimensionListTileState> {
 
   constructor(props: DimensionListTileProps) {
     super(props);

--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -168,7 +168,7 @@ export class DimensionListTile extends Component<DimensionListTileProps, Dimensi
       const noDimensionsFound = `No dimensions for "${searchText}"`;
       return <div className="message">{noDimensionsFound}</div>;
     } else {
-      return <></>;
+      return null;
     }
   }
 

--- a/src/client/components/dimension-list-tile/dimension-list-tile.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.tsx
@@ -69,6 +69,10 @@ const isFiltered = (dimension: Dimension, filter: Filter, dataCube: DataCube): b
     .contains(dimension);
 };
 
+const isSelectedDimensionPredicate = (menuDimension: Dimension) => (dimension: Dimension): boolean => {
+  return menuDimension === dimension;
+};
+
 export class DimensionListTile extends Component<DimensionListTileProps, DimensionListTileState> {
 
   constructor(props: DimensionListTileProps) {
@@ -173,7 +177,11 @@ export class DimensionListTile extends Component<DimensionListTileProps, Dimensi
     const { menuDimension, showSearch, searchText } = this.state;
     const { dataCube } = essence;
 
-    const dimensionsConverter = new DimensionsConverter(hasSearchTextPredicate(searchText), isFilteredOrSplitPredicate(essence), menuDimension);
+    const dimensionsConverter = new DimensionsConverter(
+      hasSearchTextPredicate(searchText),
+      isFilteredOrSplitPredicate(essence),
+      isSelectedDimensionPredicate(menuDimension)
+    );
     const dimensionsForView = dataCube.dimensions.accept(dimensionsConverter);
 
     const dimensionsRenderer = new DimensionsRenderer(this.clickDimension, this.dragStart, searchText);

--- a/src/client/components/dimension-list-tile/dimensions-converter.ts
+++ b/src/client/components/dimension-list-tile/dimensions-converter.ts
@@ -47,12 +47,12 @@ export class DimensionsConverter implements DimensionOrGroupVisitor<DimensionOrG
   constructor(
     private readonly hasSearchTextPredicate: (dimension: Dimension) => boolean,
     private readonly isFilteredOrSplitPredicate: (dimension: Dimension) => boolean,
-    private readonly selectedDimension: Dimension
+    private readonly isSelectedDimensionPredicate: (dimension: Dimension) => boolean
   ) {
   }
 
   visitDimension(dimension: Dimension): DimensionOrGroupForView {
-    const { hasSearchTextPredicate, isFilteredOrSplitPredicate } = this;
+    const { hasSearchTextPredicate, isFilteredOrSplitPredicate, isSelectedDimensionPredicate } = this;
     const { name, title, className } = dimension;
 
     return {
@@ -61,7 +61,7 @@ export class DimensionsConverter implements DimensionOrGroupVisitor<DimensionOrG
       classSuffix: className,
       isFilteredOrSplit: isFilteredOrSplitPredicate(dimension),
       hasSearchText: hasSearchTextPredicate(dimension),
-      selected: dimension === this.selectedDimension,
+      selected: isSelectedDimensionPredicate(dimension),
       type: DimensionForViewType.dimension
     };
   }

--- a/src/client/components/dimension-list-tile/dimensions-converter.ts
+++ b/src/client/components/dimension-list-tile/dimensions-converter.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dimension } from "../../../common/models";
+import { DimensionGroup, DimensionOrGroupVisitor } from "../../../common/models/dimension/dimension-group";
+
+export type DimensionOrGroupForView = DimensionForView | DimensionGroupForView;
+
+export interface DimensionForView {
+  name: string;
+  title: string;
+  classSuffix: string;
+  hasSearchText: boolean;
+  isFilteredOrSplit: boolean;
+  selected: boolean;
+  type: DimensionForViewType.dimension;
+}
+
+export interface DimensionGroupForView {
+  name: string;
+  title: string;
+  hasSearchText: boolean;
+  isFilteredOrSplit: boolean;
+  children: DimensionOrGroupForView[];
+  type: DimensionForViewType.group;
+}
+
+export enum DimensionForViewType {
+  dimension = "dimension",
+  group = "group"
+}
+
+export class DimensionsConverter implements DimensionOrGroupVisitor<DimensionOrGroupForView> {
+  constructor(
+    private readonly hasSearchTextPredicate: (dimension: Dimension) => boolean,
+    private readonly isFilteredOrSplitPredicate: (dimension: Dimension) => boolean,
+    private readonly selectedDimension: Dimension
+  ) {
+  }
+
+  visitDimension(dimension: Dimension): DimensionOrGroupForView {
+    const { hasSearchTextPredicate, isFilteredOrSplitPredicate } = this;
+    const { name, title, className } = dimension;
+
+    return {
+      name,
+      title,
+      classSuffix: className,
+      isFilteredOrSplit: isFilteredOrSplitPredicate(dimension),
+      hasSearchText: hasSearchTextPredicate(dimension),
+      selected: dimension === this.selectedDimension,
+      type: DimensionForViewType.dimension
+    };
+  }
+
+  visitDimensionGroup(dimensionGroup: DimensionGroup): DimensionOrGroupForView {
+    const { name, title, dimensions } = dimensionGroup;
+    const dimensionsForView = dimensions.map(item => item.accept(this));
+
+    return {
+      name,
+      title,
+      hasSearchText: dimensionsForView.some(item => item.hasSearchText),
+      isFilteredOrSplit: dimensionsForView.some(item => item.isFilteredOrSplit),
+      children: dimensionsForView,
+      type: DimensionForViewType.group
+    };
+  }
+}

--- a/src/client/components/dimension-list-tile/dimensions-renderer.tsx
+++ b/src/client/components/dimension-list-tile/dimensions-renderer.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { SearchableFolder } from "../searchable-tile/searchable-folder";
+import { DimensionClickHandler, DimensionItem } from "./dimension-item";
+import { DimensionGroupForView, DimensionOrGroupForView, DimensionForView, DimensionForViewType } from "./dimensions-converter";
+
+export class DimensionsRenderer {
+  constructor(
+    private readonly dimensionClick: DimensionClickHandler,
+    private readonly dimensionDragStart: DimensionClickHandler,
+    private readonly searchText: string
+  ) {
+  }
+
+  render(children: DimensionOrGroupForView[]): JSX.Element[] {
+    const { searchText } = this;
+    return children
+      .filter(child => !searchText || child.hasSearchText || child.type === DimensionForViewType.group)
+      .map(child => {
+        if (child.type === DimensionForViewType.group)
+          return this.renderFolder(child);
+        else
+          return this.renderMeasure(child);
+      });
+  }
+
+  renderFolder(groupView: DimensionGroupForView): JSX.Element {
+    const { searchText } = this;
+    const { name, title, hasSearchText, isFilteredOrSplit, children } = groupView;
+
+    return <SearchableFolder
+      key={name}
+      name={name}
+      title={title}
+      inSearchMode={!!searchText}
+      hasItemsWithSearchText={hasSearchText}
+      shouldBeOpened={isFilteredOrSplit}
+    >
+      {this.render(children)}
+    </SearchableFolder>;
+  }
+
+  renderMeasure(measureView: DimensionForView): JSX.Element {
+    const { dimensionClick, dimensionDragStart, searchText } = this;
+    const { name, title, classSuffix, selected } = measureView;
+
+    return <DimensionItem
+      key={name}
+      name={name}
+      title={title}
+      selected={selected}
+      dimensionClick={dimensionClick}
+      dimensionDragStart={dimensionDragStart}
+      classSuffix={classSuffix}
+      searchText={searchText}
+    />;
+  }
+}

--- a/src/client/components/dimension-list-tile/dimensions-renderer.tsx
+++ b/src/client/components/dimension-list-tile/dimensions-renderer.tsx
@@ -39,7 +39,7 @@ export class DimensionsRenderer {
       });
   }
 
-  renderFolder(groupView: DimensionGroupForView): JSX.Element {
+  private renderFolder(groupView: DimensionGroupForView): JSX.Element {
     const { searchText } = this;
     const { name, title, hasSearchText, isFilteredOrSplit, children } = groupView;
 
@@ -55,7 +55,7 @@ export class DimensionsRenderer {
     </SearchableFolder>;
   }
 
-  renderMeasure(measureView: DimensionForView): JSX.Element {
+  private renderMeasure(measureView: DimensionForView): JSX.Element {
     const { dimensionClick, dimensionDragStart, searchText } = this;
     const { name, title, classSuffix, selected } = measureView;
 

--- a/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
+++ b/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
@@ -47,8 +47,8 @@ export class DimensionMeasurePanel extends React.Component<DimensionMeasurePanel
     const { dataCube } = essence;
 
     // Compute relative sizes by diving up TOTAL_FLEXES
-    var numDimensions = dataCube.dimensions.size;
-    var numMeasures = dataCube.measures.size;
+    var numDimensions = dataCube.dimensions.size();
+    var numMeasures = dataCube.measures.size();
 
     var dimensionsFlex = clamp(
       Math.ceil(TOTAL_FLEXES * numDimensions / (numDimensions + numMeasures)),

--- a/src/client/components/measures-tile/measure-item.tsx
+++ b/src/client/components/measures-tile/measure-item.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { MouseEvent, PureComponent } from "react";
+import { classNames } from "../../utils/dom/dom";
+import { Checkbox } from "../checkbox/checkbox";
+import { HighlightString } from "../highlight-string/highlight-string";
+import { MeasureClickHandler } from "./measures-tile";
+
+export interface MeasureItemProps {
+  name: string;
+  title: string;
+  selected: boolean;
+  measureClick: MeasureClickHandler;
+  multiMeasureMode: boolean;
+  searchText: string;
+}
+
+export class MeasureItem extends PureComponent<MeasureItemProps, {}> {
+  handleClick = (e: MouseEvent<HTMLElement>) => {
+    const { name, measureClick } = this.props;
+    measureClick(name, e);
+  }
+
+  render() {
+    const { title, multiMeasureMode, searchText, selected } = this.props;
+    const checkboxType = multiMeasureMode ? 'check' : 'radio';
+
+    return <div
+      className={classNames('row', { selected })}
+      onClick={this.handleClick}
+    >
+      <Checkbox type={checkboxType} selected={selected} />
+      <HighlightString className="label" text={title} highlight={searchText} />
+    </div>;
+  }
+}

--- a/src/client/components/measures-tile/measures-converter.ts
+++ b/src/client/components/measures-tile/measures-converter.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Measure } from "../../../common/models";
+import { MeasureGroup, MeasureOrGroupVisitor } from "../../../common/models/measure/measure-group";
+
+export type MeasureOrGroupForView = MeasureForView | MeasureGroupForView;
+
+export interface MeasureForView {
+  name: string;
+  title: string;
+  hasSelectedMeasures: boolean;
+  hasSearchText: boolean;
+  type: MeasureForViewType.measure;
+}
+
+export interface MeasureGroupForView {
+  name: string;
+  title: string;
+  hasSearchText: boolean;
+  hasSelectedMeasures: boolean;
+  children: MeasureOrGroupForView[];
+  type: MeasureForViewType.group;
+}
+
+export enum MeasureForViewType {
+  measure = "measure",
+  group = "group"
+}
+
+export class MeasuresConverter implements MeasureOrGroupVisitor<MeasureOrGroupForView> {
+  constructor(
+    private hasSearchTextPredicate: (measure: Measure) => boolean,
+    private isSelectedMeasurePredicate: (measure: Measure) => boolean
+  ) {
+  }
+
+  visitMeasure(measure: Measure): MeasureOrGroupForView {
+    const { hasSearchTextPredicate, isSelectedMeasurePredicate } = this;
+
+    return {
+      name: measure.name,
+      title: measure.getTitleWithUnits(),
+      hasSelectedMeasures: isSelectedMeasurePredicate(measure),
+      hasSearchText: hasSearchTextPredicate(measure),
+      type: MeasureForViewType.measure
+    };
+  }
+
+  visitMeasureGroup(measureGroup: MeasureGroup): MeasureOrGroupForView {
+    const { name, title, measures } = measureGroup;
+    const measuresForView = measures.map(measureOrGroup => measureOrGroup.accept(this));
+
+    return {
+      name,
+      title,
+      hasSearchText: measuresForView.some(measureForView => measureForView.hasSearchText),
+      hasSelectedMeasures: measuresForView.some(measureForView => measureForView.hasSelectedMeasures),
+      children: measuresForView,
+      type: MeasureForViewType.group
+    };
+  }
+}

--- a/src/client/components/measures-tile/measures-renderer.tsx
+++ b/src/client/components/measures-tile/measures-renderer.tsx
@@ -30,8 +30,13 @@ export class MeasuresRenderer {
 
   render(children: MeasureOrGroupForView[]): JSX.Element[] {
     const { searchText } = this;
+
+    const notInSearchModeOrHasSearchTextOrIsGroup = (item: MeasureOrGroupForView) => {
+      return !searchText || item.hasSearchText || item.type === MeasureForViewType.group;
+    };
+
     return children
-      .filter(child => !searchText || child.hasSearchText || child.type === MeasureForViewType.group)
+      .filter(notInSearchModeOrHasSearchTextOrIsGroup)
       .map(child => {
         if (child.type === MeasureForViewType.group)
           return this.renderFolder(child);

--- a/src/client/components/measures-tile/measures-renderer.tsx
+++ b/src/client/components/measures-tile/measures-renderer.tsx
@@ -40,7 +40,7 @@ export class MeasuresRenderer {
       });
   }
 
-  renderFolder(groupView: MeasureGroupForView): JSX.Element {
+  private renderFolder(groupView: MeasureGroupForView): JSX.Element {
     const { searchText } = this;
     const { name, title, hasSearchText, hasSelectedMeasures, children } = groupView;
 
@@ -56,7 +56,7 @@ export class MeasuresRenderer {
     </SearchableFolder>;
   }
 
-  renderMeasure(measureView: MeasureForView): JSX.Element {
+  private renderMeasure(measureView: MeasureForView): JSX.Element {
     const { measureClick, multiMeasureMode, searchText } = this;
     const { name, title, hasSelectedMeasures } = measureView;
 

--- a/src/client/components/measures-tile/measures-renderer.tsx
+++ b/src/client/components/measures-tile/measures-renderer.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { SearchableFolder } from "../searchable-tile/searchable-folder";
+import { MeasureItem } from "./measure-item";
+import { MeasureForViewType, MeasureGroupForView, MeasureOrGroupForView, MeasureForView } from "./measures-converter";
+import { MeasureClickHandler } from "./measures-tile";
+
+export class MeasuresRenderer {
+  constructor(
+    private readonly measureClick: MeasureClickHandler,
+    private readonly multiMeasureMode: boolean,
+    private readonly searchText: string
+  ) {
+  }
+
+  render(children: MeasureOrGroupForView[]): JSX.Element[] {
+    const { searchText } = this;
+    return children
+      .filter(child => !searchText || child.hasSearchText || child.type === MeasureForViewType.group)
+      .map(child => {
+        if (child.type === MeasureForViewType.group)
+          return this.renderFolder(child);
+        else
+          return this.renderMeasure(child);
+      });
+  }
+
+  renderFolder(groupView: MeasureGroupForView): JSX.Element {
+    const { searchText } = this;
+    const { name, title, hasSearchText, hasSelectedMeasures, children } = groupView;
+
+    return <SearchableFolder
+      key={name}
+      name={name}
+      title={title}
+      inSearchMode={!!searchText}
+      hasItemsWithSearchText={hasSearchText}
+      shouldBeOpened={hasSelectedMeasures}
+    >
+      {this.render(children)}
+    </SearchableFolder>;
+  }
+
+  renderMeasure(measureView: MeasureForView): JSX.Element {
+    const { measureClick, multiMeasureMode, searchText } = this;
+    const { name, title, hasSelectedMeasures } = measureView;
+
+    return <MeasureItem
+      key={name}
+      name={name}
+      title={title}
+      selected={hasSelectedMeasures}
+      measureClick={measureClick}
+      multiMeasureMode={multiMeasureMode}
+      searchText={searchText}
+    />;
+  }
+}

--- a/src/client/components/measures-tile/measures-tile.scss
+++ b/src/client/components/measures-tile/measures-tile.scss
@@ -18,32 +18,31 @@
 @import '../../imports';
 
 .measures-tile {
-  .row {
-    padding-left: $padding-compact;
-    height: $measure-height;
-    cursor: pointer;
-    overflow: hidden;
-    white-space: nowrap;
+  $icon-width: 37px;
 
-    &:last-child {
-      margin-bottom: 12px;
+  .rows {
+    .row {
+      padding-left: $padding-compact;
+      height: $measure-height;
+      cursor: pointer;
+      overflow: hidden;
+      white-space: nowrap;
+
+      .label {
+        @include ellipsis;
+        display: block;
+        padding: 7px 0.15em;
+      }
+
+      &:hover {
+        background: $hover;
+      }
     }
 
-    .label {
-      @include ellipsis;
-      position: absolute;
-      top: 7px;
-      bottom: 0;
-      left: 37px;
-      right: 10px;
-    }
-
-    &:hover {
-      background: $hover;
+    .checkbox {
+      margin-top: 2px;
+      float: left;
     }
   }
 
-  .checkbox {
-    margin-top: 2px;
-  }
 }

--- a/src/client/components/measures-tile/measures-tile.tsx
+++ b/src/client/components/measures-tile/measures-tile.tsx
@@ -15,58 +15,57 @@
  * limitations under the License.
  */
 
+import { OrderedSet } from "immutable";
+import * as React from "react";
+import { MouseEvent } from "react";
+import { Clicker, Essence, Measure } from '../../../common/models';
+import { MAX_SEARCH_LENGTH, STRINGS } from '../../config/constants';
+import * as localStorage from '../../utils/local-storage/local-storage';
+import { SearchableTile } from '../searchable-tile/searchable-tile';
+import { TileHeaderIcon } from '../tile-header/tile-header';
+import { MeasureOrGroupForView, MeasuresConverter } from "./measures-converter";
+import { MeasuresRenderer } from "./measures-renderer";
 import './measures-tile.scss';
 
-import * as React from 'react';
-
-import { STRINGS, PIN_TITLE_HEIGHT, MEASURE_HEIGHT, PIN_PADDING_BOTTOM, MAX_SEARCH_LENGTH } from '../../config/constants';
-import { Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
-import { classNames } from '../../utils/dom/dom';
-import * as localStorage from '../../utils/local-storage/local-storage';
-
-import { Checkbox, CheckboxType } from '../checkbox/checkbox';
-import { TileHeaderIcon } from '../tile-header/tile-header';
-import { HighlightString } from '../highlight-string/highlight-string';
-import { SearchableTile } from '../searchable-tile/searchable-tile';
-
-export interface MeasuresTileProps extends React.Props<any> {
+export interface MeasuresTileProps {
   clicker: Clicker;
   essence: Essence;
   style?: React.CSSProperties;
 }
 
-export interface MeasuresTileState {
-  showSearch?: boolean;
-  searchText?: string;
-}
+export const initialState = {
+  showSearch: false,
+  searchText: ""
+};
+
+export type MeasuresTileState = Readonly<typeof initialState>;
+
+export type MeasureClickHandler = (measureName: string, e: MouseEvent<HTMLElement>) => void;
+
+const hasSearchTextPredicate = (searchText: string) => (measure: Measure): boolean => {
+  return searchText != null && searchText !== "" && measure.title.toLowerCase().includes(searchText.toLowerCase());
+};
+
+const isSelectedMeasurePredicate = (selectedMeasures: OrderedSet<string>) => (measure: Measure): boolean => {
+  return selectedMeasures.contains(measure.name);
+};
 
 export class MeasuresTile extends React.Component<MeasuresTileProps, MeasuresTileState> {
+  readonly state: MeasuresTileState = initialState;
 
-  constructor(props: MeasuresTileProps) {
-    super(props);
-    this.state = {
-      showSearch: false,
-      searchText: ''
-    };
-  }
-
-  measureClick(measure: Measure, e: MouseEvent) {
-    if (e.altKey && typeof console !== 'undefined') {
-      console.log(`Measure: ${measure.name}`);
-      console.log(`expression: ${measure.expression.toString()}`);
-      return;
-    }
-    var { clicker } = this.props;
+  measureClick = (measureName: string) => {
+    const { clicker, essence: { dataCube } } = this.props;
+    const measure = dataCube.measures.getMeasureByName(measureName);
     clicker.toggleEffectiveMeasure(measure);
   }
 
-  toggleSearch() {
+  toggleSearch = () => {
     var { showSearch } = this.state;
     this.setState({ showSearch: !showSearch });
     this.onSearchChange('');
   }
 
-  onSearchChange(text: string) {
+  onSearchChange = (text: string) => {
     var { searchText } = this.state;
     var newSearchText = text.substr(0, MAX_SEARCH_LENGTH);
 
@@ -77,52 +76,42 @@ export class MeasuresTile extends React.Component<MeasuresTileProps, MeasuresTil
     });
   }
 
-  toggleMultiMeasure() {
+  toggleMultiMeasure = () => {
     var { clicker, essence } = this.props;
     clicker.toggleMultiMeasureMode();
     localStorage.set('is-multi-measure', !essence.getEffectiveMultiMeasureMode());
   }
 
+  renderMessageIfNoMeasuresFound(measuresForView: MeasureOrGroupForView[]): JSX.Element {
+    const { searchText } = this.state;
+
+    if (!!searchText && !measuresForView.some(measure => measure.hasSearchText)) {
+      return <div className="message">{`No ${ STRINGS.measures.toLowerCase() } for "${searchText}"`}</div>;
+    } else {
+      return <></>;
+    }
+  }
+
   render() {
-    var { essence, style } = this.props;
-    var { showSearch, searchText } = this.state;
-    var { dataCube } = essence;
-    var multiMeasureMode = essence.getEffectiveMultiMeasureMode();
-    var selectedMeasures = essence.getEffectiveSelectedMeasure();
+    const { essence, style } = this.props;
+    const { showSearch, searchText } = this.state;
+    const { dataCube } = essence;
+    const multiMeasureMode = essence.getEffectiveMultiMeasureMode();
+    const selectedMeasures = essence.getEffectiveSelectedMeasure();
 
-    var checkboxType: CheckboxType = multiMeasureMode ? 'check' : 'radio';
+    const measuresConverter = new MeasuresConverter(hasSearchTextPredicate(searchText), isSelectedMeasurePredicate(selectedMeasures));
+    const measuresForView = dataCube.measures.accept(measuresConverter);
 
-    var shownMeasures = dataCube.measures.toArray();
-    if (searchText) {
-      shownMeasures = shownMeasures.filter((m) => {
-        return m.getTitleWithUnits().toLowerCase().indexOf(searchText.toLowerCase()) !== -1;
-      });
-    }
+    const measuresRenderer = new MeasuresRenderer(this.measureClick, multiMeasureMode, searchText);
+    const rows = measuresRenderer.render(measuresForView);
+    const message = this.renderMessageIfNoMeasuresFound(measuresForView);
 
-    var rows = shownMeasures.map(measure => {
-      var measureName = measure.name;
-      var selected = selectedMeasures.has(measureName);
-      return <div
-        className={classNames('row', { selected })}
-        key={measureName}
-        onClick={this.measureClick.bind(this, measure)}
-      >
-        <Checkbox type={checkboxType} selected={selected}/>
-        <HighlightString className="label" text={measure.getTitleWithUnits()} highlight={searchText}/>
-      </div>;
-    });
-
-    var message: JSX.Element = null;
-    if (searchText && !rows.length) {
-      message = <div className="message">{`No ${ STRINGS.measures.toLowerCase() } for "${searchText}"`}</div>;
-    }
-
-    var icons: TileHeaderIcon[] = [];
+    const icons: TileHeaderIcon[] = [];
 
     if (!essence.isFixedMeasureMode()) {
       icons.push({
         name: 'multi',
-        onClick: this.toggleMultiMeasure.bind(this),
+        onClick: this.toggleMultiMeasure,
         svg: require('../../icons/full-multi.svg'),
         active: multiMeasureMode
       });
@@ -131,29 +120,25 @@ export class MeasuresTile extends React.Component<MeasuresTileProps, MeasuresTil
     icons.push({
       name: 'search',
       ref: 'search',
-      onClick: this.toggleSearch.bind(this),
+      onClick: this.toggleSearch,
       svg: require('../../icons/full-search.svg'),
       active: showSearch
     });
 
-    // More icons to add later
-    //{ name: 'more', onClick: null, svg: require('../../icons/full-more-mini.svg') }
-
     return <SearchableTile
       style={style}
       title={STRINGS.measures}
-      toggleChangeFn={this.toggleSearch.bind(this)}
-      onSearchChange={this.onSearchChange.bind(this)}
+      toggleChangeFn={this.toggleSearch}
+      onSearchChange={this.onSearchChange}
       searchText={searchText}
       showSearch={showSearch}
       icons={icons}
       className='measures-tile'
     >
       <div className="rows">
-        { rows }
-        { message }
+        {rows}
+        {message}
       </div>
     </SearchableTile>;
   }
 }
-

--- a/src/client/components/measures-tile/measures-tile.tsx
+++ b/src/client/components/measures-tile/measures-tile.tsx
@@ -89,7 +89,7 @@ export class MeasuresTile extends Component<MeasuresTileProps, MeasuresTileState
       const noMeasuresFound = `No measures for "${searchText}"`;
       return <div className="message">{noMeasuresFound}</div>;
     } else {
-      return <></>;
+      return null;
     }
   }
 

--- a/src/client/components/measures-tile/measures-tile.tsx
+++ b/src/client/components/measures-tile/measures-tile.tsx
@@ -17,7 +17,7 @@
 
 import { OrderedSet } from "immutable";
 import * as React from "react";
-import { MouseEvent } from "react";
+import { Component, MouseEvent } from "react";
 import { Clicker, Essence, Measure } from '../../../common/models';
 import { MAX_SEARCH_LENGTH, STRINGS } from '../../config/constants';
 import * as localStorage from '../../utils/local-storage/local-storage';
@@ -50,7 +50,7 @@ const isSelectedMeasurePredicate = (selectedMeasures: OrderedSet<string>) => (me
   return selectedMeasures.contains(measure.name);
 };
 
-export class MeasuresTile extends React.Component<MeasuresTileProps, MeasuresTileState> {
+export class MeasuresTile extends Component<MeasuresTileProps, MeasuresTileState> {
   readonly state: MeasuresTileState = initialState;
 
   measureClick = (measureName: string) => {

--- a/src/client/components/measures-tile/measures-tile.tsx
+++ b/src/client/components/measures-tile/measures-tile.tsx
@@ -86,7 +86,8 @@ export class MeasuresTile extends Component<MeasuresTileProps, MeasuresTileState
     const { searchText } = this.state;
 
     if (!!searchText && !measuresForView.some(measure => measure.hasSearchText)) {
-      return <div className="message">{`No ${ STRINGS.measures.toLowerCase() } for "${searchText}"`}</div>;
+      const noMeasuresFound = `No measures for "${searchText}"`;
+      return <div className="message">{noMeasuresFound}</div>;
     } else {
       return <></>;
     }

--- a/src/client/components/pinboard-measure-tile/pinboard-measure-tile.tsx
+++ b/src/client/components/pinboard-measure-tile/pinboard-measure-tile.tsx
@@ -38,7 +38,7 @@ export class PinboardMeasureTile extends React.Component<PinboardMeasureTileProp
     var { essence, title, dimension, sortOn, onSelect } = this.props;
 
     var sortOns = (dimension ? [SortOn.fromDimension(dimension)] : []).concat(
-      essence.dataCube.measures.toArray().map(SortOn.fromMeasure)
+      essence.dataCube.measures.mapMeasures(SortOn.fromMeasure)
     );
 
     const SortOnDropdown = Dropdown.specialize<SortOn>();

--- a/src/client/components/searchable-tile/searchable-folder.tsx
+++ b/src/client/components/searchable-tile/searchable-folder.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { PureComponent } from "react";
+import { SvgIcon } from "..";
+import { classNames } from "../../utils/dom/dom";
+
+export interface SearchableFolderProps {
+  name: string;
+  title: string;
+  inSearchMode: boolean;
+  hasItemsWithSearchText: boolean;
+  shouldBeOpened: boolean;
+}
+
+export interface SearchableFolderState {
+  opened: boolean;
+}
+
+export class SearchableFolder extends PureComponent<SearchableFolderProps, SearchableFolderState> {
+
+  readonly state: SearchableFolderState;
+
+  constructor(props: SearchableFolderProps) {
+    super(props);
+
+    const { inSearchMode, hasItemsWithSearchText, shouldBeOpened } = this.props;
+    this.state = { opened: inSearchMode && hasItemsWithSearchText || shouldBeOpened };
+  }
+
+  componentWillReceiveProps(nextProps: Readonly<SearchableFolderProps>) {
+    const { opened } = this.state;
+    const { shouldBeOpened } = this.props;
+
+    const shouldOpen = !opened && !shouldBeOpened && nextProps.shouldBeOpened;
+    if (shouldOpen) {
+      this.setState({ opened: shouldOpen });
+    }
+  }
+
+  handleClick = () => {
+    this.setState((prevState) => ({ opened: !prevState.opened }));
+  }
+
+  render() {
+    const { title, inSearchMode, hasItemsWithSearchText, children } = this.props;
+    const { opened } = this.state;
+
+    const isGroupOpen = opened || inSearchMode && hasItemsWithSearchText;
+    const hidden = inSearchMode && !hasItemsWithSearchText;
+
+    const openIcon = <SvgIcon svg={require("../../icons/full-caret-small-bottom.svg")} />;
+    const closedIcon = <SvgIcon svg={require("../../icons/full-caret-small-right.svg")} />;
+
+    return <div className={classNames("folder", { hidden })}>
+      <div className={classNames("folder-header")} onClick={this.handleClick}>
+        <div className={"folder-icon"}>{isGroupOpen ? openIcon : closedIcon}</div>
+        <span className={"label"}>{title}</span>
+      </div>
+      <div className={classNames("folder-items", { closed: !isGroupOpen})}>
+        {children}
+      </div>
+    </div>;
+  }
+}

--- a/src/client/components/searchable-tile/searchable-folder.tsx
+++ b/src/client/components/searchable-tile/searchable-folder.tsx
@@ -35,6 +35,9 @@ export class SearchableFolder extends PureComponent<SearchableFolderProps, Searc
 
   readonly state: SearchableFolderState;
 
+  private readonly openIcon = <SvgIcon svg={require("../../icons/full-caret-small-bottom.svg")} />;
+  private readonly closedIcon = <SvgIcon svg={require("../../icons/full-caret-small-right.svg")} />;
+
   constructor(props: SearchableFolderProps) {
     super(props);
 
@@ -63,12 +66,9 @@ export class SearchableFolder extends PureComponent<SearchableFolderProps, Searc
     const isGroupOpen = opened || inSearchMode && hasItemsWithSearchText;
     const hidden = inSearchMode && !hasItemsWithSearchText;
 
-    const openIcon = <SvgIcon svg={require("../../icons/full-caret-small-bottom.svg")} />;
-    const closedIcon = <SvgIcon svg={require("../../icons/full-caret-small-right.svg")} />;
-
     return <div className={classNames("folder", { hidden })}>
       <div className={classNames("folder-header")} onClick={this.handleClick}>
-        <div className={"folder-icon"}>{isGroupOpen ? openIcon : closedIcon}</div>
+        <div className={"folder-icon"}>{isGroupOpen ? this.openIcon : this.closedIcon}</div>
         <span className={"label"}>{title}</span>
       </div>
       <div className={classNames("folder-items", { closed: !isGroupOpen})}>

--- a/src/client/components/searchable-tile/searchable-tile.scss
+++ b/src/client/components/searchable-tile/searchable-tile.scss
@@ -32,8 +32,13 @@ $search-box-height: 26px;
     right: 0;
 
     overflow: auto;
-  }
 
+    .row {
+      &:last-child {
+        margin-bottom: $searchable-tile-last-child-margin;
+      }
+    }
+  }
 
   .search-box {
     position: absolute;
@@ -56,7 +61,6 @@ $search-box-height: 26px;
     }
   }
 
-
   &.has-search .rows {
     top: $pin-title-height + $search-box-height + $search-box-gap;
   }
@@ -67,6 +71,59 @@ $search-box-height: 26px;
 
   &.continuous .rows .row {
     pointer-events: none;
+  }
+
+  .folder {
+    .folder-header {
+      background: $white;
+      cursor: pointer;
+      overflow: hidden;
+      padding-left: 14px;
+      height: $dimension-height;
+
+      &:hover {
+        background: $hover;
+      }
+
+      .label {
+        @include ellipsis;
+        display: block;
+        padding: 7px 0.15em;
+      }
+
+      .folder-icon {
+        top: 4px;
+        left: -2px;
+        width: 19px;
+        float: left;
+
+        svg {
+          width: 19px;
+
+          path {
+            fill: hsla(0, 0, 0, 0.35);
+          }
+        }
+      }
+    }
+
+    .folder-items {
+      padding-left: 22px;
+
+      .row {
+        &:last-child {
+          margin-bottom: $searchable-folder-last-child-margin;
+        }
+      }
+    }
+
+    .closed {
+      display: none;
+    }
+  }
+
+  .hidden {
+    display: none;
   }
 
   .message {

--- a/src/client/components/split-menu/split-menu.tsx
+++ b/src/client/components/split-menu/split-menu.tsx
@@ -192,7 +192,7 @@ export class SplitMenu extends React.Component<SplitMenuProps, SplitMenuState> {
   renderSortDropdown() {
     var { essence, dimension } = this.props;
 
-    var sortOns = [SortOn.fromDimension(dimension)].concat(essence.dataCube.measures.toArray().map(SortOn.fromMeasure));
+    var sortOns = [SortOn.fromDimension(dimension)].concat(essence.dataCube.measures.mapMeasures(SortOn.fromMeasure));
 
     const SortOnDropdown = Dropdown.specialize<SortOn>();
 

--- a/src/client/components/vis-measure-label/vis-measure-label.tsx
+++ b/src/client/components/vis-measure-label/vis-measure-label.tsx
@@ -37,7 +37,7 @@ export class VisMeasureLabel extends React.Component<VisMeasureLabelProps, VisMe
     return <div className="vis-measure-label">
       <span className="measure-title">{measure.title}</span>
       <span className="colon">: </span>
-      <span className="measure-value">{measure.formatFn(datum[measure.name] as number)}</span>
+      <span className="measure-value">{measure.formatDatum(datum)}</span>
     </div>;
   }
 }

--- a/src/client/config/_constants.scss
+++ b/src/client/config/_constants.scss
@@ -30,6 +30,9 @@ $padding: 18px;
 $padding-compact: 14px;
 $padding-mini: 10px;
 
+$searchable-tile-last-child-margin: 12px;
+$searchable-folder-last-child-margin: 0;
+
 // Vis
 $vis-h-padding: 10px;
 

--- a/src/client/modals/dimension-modal/dimension-modal.tsx
+++ b/src/client/modals/dimension-modal/dimension-modal.tsx
@@ -24,7 +24,7 @@ import { List } from 'immutable';
 
 import { SvgIcon, FormLabel, Button, ImmutableInput, Modal, ImmutableDropdown } from '../../components/index';
 
-import { Dimension, ListItem, granularityFromJS, granularityToString } from '../../../common/models/index';
+import { Dimension, ListItem, granularityFromJS, granularityToString, BucketingStrategy } from '../../../common/models/index';
 
 import { DIMENSION as LABELS } from '../../../common/models/labels';
 
@@ -46,8 +46,8 @@ export class DimensionModal extends React.Component<DimensionModalProps, Immutab
   ];
 
   static BUCKETING_STRATEGIES = [
-    {label: 'Bucket', value: Dimension.defaultBucket},
-    {label: 'Don’t Bucket', value: Dimension.defaultNoBucket}
+    {label: 'Bucket', value: BucketingStrategy.defaultBucket},
+    {label: 'Don’t Bucket', value: BucketingStrategy.defaultNoBucket}
   ];
 
   private delegate: ImmutableFormDelegate<Dimension>;

--- a/src/client/views/settings-view/data-cube-edit/data-cube-edit.tsx
+++ b/src/client/views/settings-view/data-cube-edit/data-cube-edit.tsx
@@ -20,6 +20,7 @@ import './data-cube-edit.scss';
 import * as React from 'react';
 import { List } from 'immutable';
 import { AttributeInfo } from 'plywood';
+import { Dimensions } from "../../../../common/models/dimension/dimensions";
 import { classNames } from '../../../utils/dom/dom';
 
 import { generateUniqueName } from '../../../../common/utils/string/string';
@@ -213,7 +214,7 @@ export class DataCubeEdit extends React.Component<DataCubeEditProps, DataCubeEdi
   renderDimensions(): JSX.Element {
     const { newInstance } = this.state;
 
-    const onChange = (newDimensions: List<Dimension>) => {
+    const onChange = (newDimensions: Dimensions) => {
       const newCube = newInstance.changeDimensions(newDimensions);
       this.setState({
         newInstance: newCube
@@ -223,7 +224,7 @@ export class DataCubeEdit extends React.Component<DataCubeEditProps, DataCubeEdi
     const getModal = (item: Dimension) => <DimensionModal dimension={item}/>;
 
     const getNewItem = () => Dimension.fromJS({
-      name: generateUniqueName('d', name => !newInstance.dimensions.find(m => m.name === name)),
+      name: generateUniqueName('d', name => !newInstance.dimensions.containsDimensionWithName(name)),
       title: 'New dimension'
     });
 
@@ -239,7 +240,7 @@ export class DataCubeEdit extends React.Component<DataCubeEditProps, DataCubeEdi
 
     return <DimensionsList
       label={STRINGS.dimensions}
-      items={newInstance.dimensions}
+      items={List()} // empty list of dimensions for now
       onChange={onChange.bind(this)}
       getModal={getModal}
       getNewItem={getNewItem}
@@ -303,7 +304,7 @@ export class DataCubeEdit extends React.Component<DataCubeEditProps, DataCubeEdi
     const getModal = (item: Measure) => <MeasureModal measure={item}/>;
 
     const getNewItem = () => Measure.fromJS({
-      name: generateUniqueName('m', name => !newInstance.measures.find(m => m.name === name)),
+      name: generateUniqueName('m', name => !newInstance.measures.containsMeasureWithName(name)),
       title: 'New measure'
     });
 
@@ -319,7 +320,7 @@ export class DataCubeEdit extends React.Component<DataCubeEditProps, DataCubeEdi
 
     return <MeasuresList
       label={STRINGS.measures}
-      items={newInstance.measures}
+      items={List()} // empty list of measures for now
       onChange={onChange.bind(this)}
       getModal={getModal}
       getNewItem={getNewItem}

--- a/src/common/manifests/bar-chart/bar-chart.ts
+++ b/src/common/manifests/bar-chart/bar-chart.ts
@@ -100,12 +100,12 @@ var rulesEvaluator = visualizationDependentEvaluatorBuilder
   })
 
   .otherwise(({ splits, dataCube }) => {
-    let categoricalDimensions = dataCube.dimensions.filter((d) => d.kind !== 'time');
+    const categoricalDimensions = dataCube.dimensions.filterDimensions((dimension) => dimension.kind !== 'time');
 
     return Resolve.manual(
       3,
       'The Bar Chart needs one or two splits',
-      categoricalDimensions.toArray().slice(0, 2).map((dimension: Dimension) => {
+      categoricalDimensions.slice(0, 2).map((dimension: Dimension) => {
         return {
           description: `Split on ${dimension.title} instead`,
           adjustment: {

--- a/src/common/manifests/line-chart/line-chart.ts
+++ b/src/common/manifests/line-chart/line-chart.ts
@@ -23,14 +23,14 @@ import { Predicates } from "../../utils/rules/predicates";
 import { visualizationDependentEvaluatorBuilder } from "../../utils/rules/visualization-dependent-evaluator";
 
 const rulesEvaluator = visualizationDependentEvaluatorBuilder
-  .when(({ dataCube }) => !(dataCube.getDimensionByKind('time') || dataCube.getDimensionByKind('number')))
+  .when(({ dataCube }) => !(dataCube.getDimensionsByKind('time').length || dataCube.getDimensionsByKind('number').length))
   .then(() => Resolve.NEVER)
 
   .when(Predicates.noSplits())
   .then(({ splits, dataCube }) => {
-    const continuousDimensions = dataCube.getDimensionByKind('time').concat(dataCube.getDimensionByKind('number'));
+    const continuousDimensions = dataCube.getDimensionsByKind('time').concat(dataCube.getDimensionsByKind('number'));
     return Resolve.manual(3, 'This visualization requires a continuous dimension split',
-      continuousDimensions.toArray().map((continuousDimension) => {
+      continuousDimensions.map((continuousDimension) => {
         return {
           description: `Add a split on ${continuousDimension.title}`,
           adjustment: {
@@ -183,9 +183,9 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
   })
 
   .otherwise(({ splits, dataCube }) => {
-    let continuousDimensions = dataCube.getDimensionByKind('time').concat(dataCube.getDimensionByKind('number'));
+    let continuousDimensions = dataCube.getDimensionsByKind('time').concat(dataCube.getDimensionsByKind('number'));
     return Resolve.manual(3, 'The Line Chart needs one continuous dimension split',
-      continuousDimensions.toArray().map((continuousDimension) => {
+      continuousDimensions.map((continuousDimension) => {
         return {
           description: `Split on ${continuousDimension.title} instead`,
           adjustment: {

--- a/src/common/models/app-settings/app-settings.mocha.ts
+++ b/src/common/models/app-settings/app-settings.mocha.ts
@@ -188,10 +188,28 @@ describe('AppSettings', () => {
                 "title": 'Channel'
               },
               {
-                "formula": '$commentLength',
-                "kind": 'number',
-                "name": 'commentLength',
-                "title": 'Comment Length'
+                "name": "comment_group",
+                "title": "Comment Group",
+                "dimensions": [
+                  {
+                    "kind": "string",
+                    "name": "comment",
+                    "title": "Comment",
+                    "formula": "$comment"
+                  },
+                  {
+                    "kind": "number",
+                    "name": "commentLength",
+                    "title": "Comment Length",
+                    "formula": "$commentLength"
+                  },
+                  {
+                    "kind": "boolean",
+                    "name": "commentLengthOver100",
+                    "title": "Comment Length Over 100",
+                    "formula": "$commentLength > 100"
+                  }
+                ]
               },
               {
                 "formula": '$isRobot',
@@ -231,14 +249,42 @@ describe('AppSettings', () => {
                 "title": "Count"
               },
               {
-                "formula": "$main.sum($added)",
-                "name": "added",
-                "title": "Added"
-              },
-              {
-                "formula": '$main.sum($delta)',
-                "name": 'delta',
-                "title": 'Delta'
+                "name": "other",
+                "title": "Other",
+                "measures": [
+                  {
+                    "name": "added_group",
+                    "title": "Added Group",
+                    "measures": [
+                      {
+                        "name": "added",
+                        "title": "Added",
+                        "formula": "$main.sum($added)"
+                      },
+                      {
+                        "name": "avg_added",
+                        "title": "Avg Added",
+                        "formula": "$main.average($added)"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "delta_group",
+                    "title": "Delta Group",
+                    "measures": [
+                      {
+                        "name": "delta",
+                        "title": "Delta",
+                        "formula": "$main.sum($delta)"
+                      },
+                      {
+                        "name": "avg_delta",
+                        "title": "Avg Delta",
+                        "formula": "$main.average($delta)"
+                      }
+                    ]
+                  }
+                ]
               }
             ],
             "name": "wiki",

--- a/src/common/models/data-cube/data-cube.mocha.ts
+++ b/src/common/models/data-cube/data-cube.mocha.ts
@@ -121,7 +121,7 @@ describe('DataCube', () => {
             }
           ]
         });
-      }).to.throw("name 'articleName' found in both dimensions and measures in data cube: 'wiki'");
+      }).to.throw("data cube: 'wiki', names: 'articleName' found in both dimensions and measures");
     });
 
     it("throws an error if duplicate name is used in measures", () => {
@@ -152,7 +152,7 @@ describe('DataCube', () => {
             }
           ]
         });
-      }).to.throw("duplicate measure name 'articleName' found in data cube: 'wiki'");
+      }).to.throw("data cube: 'wiki', found duplicate measure or group with names: 'articleName'");
     });
 
     it("throws an error if duplicate name is used in dimensions", () => {
@@ -183,7 +183,7 @@ describe('DataCube', () => {
             }
           ]
         });
-      }).to.throw("duplicate dimension name 'articleName' found in data cube: 'wiki'");
+      }).to.throw("data cube: 'wiki', found duplicate dimension or group with names: 'articleName'");
     });
 
   });

--- a/src/common/models/data-cube/data-cube.mock.ts
+++ b/src/common/models/data-cube/data-cube.mock.ts
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-import { $, Executor, Dataset, basicExecutorFactory } from 'plywood';
+import { Dataset, basicExecutorFactory } from 'plywood';
+import { DimensionsFixtures } from "../dimension/dimensions.fixtures";
+import { MeasuresFixtures } from "../measure/measures.fixtures";
 import { DataCube, DataCubeJS } from './data-cube';
 
 var executor = basicExecutorFactory({
@@ -41,73 +43,8 @@ export class DataCubeMock {
         { name: 'userChars', type: 'SET/STRING' },
         { name: 'count', type: 'NUMBER', unsplitable: true, maker: { op: 'count' } }
       ],
-      dimensions: [
-        {
-          kind: 'time',
-          name: 'time',
-          title: 'Time',
-          formula: '$time'
-        },
-        {
-          kind: 'string',
-          name: 'channel',
-          title: 'Channel',
-          formula: '$channel'
-        },
-        {
-          kind: 'number',
-          name: 'commentLength',
-          title: 'Comment Length',
-          formula: '$commentLength'
-        },
-        {
-          kind: 'string',
-          name: 'isRobot',
-          title: 'Is Robot',
-          formula: '$isRobot'
-        },
-        {
-          kind: 'string',
-          name: 'namespace',
-          title: 'Namespace',
-          formula: '$namespace'
-        },
-        {
-          kind: 'string',
-          name: 'articleName',
-          title: 'Article Name',
-          formula: '$articleName'
-        },
-        {
-          kind: 'string',
-          name: 'page',
-          title: 'Page',
-          formula: '$page'
-        },
-        {
-          kind: 'string',
-          name: 'userChars',
-          title: 'User Chars',
-          formula: '$userChars'
-        }
-      ],
-      measures: [
-        {
-          name: 'count',
-          title: 'Count',
-          formula: '$main.sum($count)'
-        },
-        {
-          name: 'added',
-          title: 'Added',
-          formula: '$main.sum($added)'
-        },
-        {
-          name: 'delta',
-          title: 'Delta',
-          formula: '$main.sum($delta)'
-        }
-      ],
+      dimensions: DimensionsFixtures.wikiJS(),
+      measures: MeasuresFixtures.wikiJS(),
       timeAttribute: 'time',
       defaultTimezone: 'Etc/UTC',
       defaultFilter: { op: 'literal', value: true },
@@ -130,33 +67,8 @@ export class DataCubeMock {
       clusterName: 'druid-twitter',
       source: 'twitter',
       introspection: 'none',
-      dimensions: [
-        {
-          kind: 'time',
-          name: 'time',
-          title: 'Time',
-          formula: '$time'
-        },
-        {
-          kind: 'string',
-          name: 'twitterHandle',
-          title: 'Twitter Handle',
-          formula: '$twitterHandle'
-        },
-        {
-          kind: 'number',
-          name: 'tweetLength',
-          title: 'Tweet Length',
-          formula: '$tweetLength'
-        }
-      ],
-      measures: [
-        {
-          name: 'count',
-          title: 'count',
-          formula: '$main.count()'
-        }
-      ],
+      dimensions: DimensionsFixtures.twitterJS(),
+      measures: MeasuresFixtures.twitterJS(),
       timeAttribute: 'time',
       defaultTimezone: 'Etc/UTC',
       defaultFilter: { op: 'literal', value: true },

--- a/src/common/models/data-cube/data-cube.ts
+++ b/src/common/models/data-cube/data-cube.ts
@@ -52,7 +52,7 @@ function formatTimeDiff(diff: number): string {
   return diff + ' days';
 }
 
-function checkUniquenessOfNamesAcrossDimensionsAndMeasures(dimensions: Dimensions, measures: Measures, dataCubeName: string) {
+function checkDimensionsAndMeasuresNamesUniqueness(dimensions: Dimensions, measures: Measures, dataCubeName: string) {
   if (dimensions != null && measures != null) {
     const dimensionNames = dimensions.getDimensionNames();
     const measureNames = measures.getMeasureNames();
@@ -433,7 +433,7 @@ export class DataCube implements Instance<DataCubeValue, DataCubeJS> {
 
     var dimensions = parameters.dimensions;
     var measures = parameters.measures;
-    checkUniquenessOfNamesAcrossDimensionsAndMeasures(dimensions, measures, name);
+    checkDimensionsAndMeasuresNamesUniqueness(dimensions, measures, name);
 
     this.dimensions = dimensions || Dimensions.empty();
     this.measures = measures || Measures.empty();

--- a/src/common/models/dimension/dimension-group.fixtures.ts
+++ b/src/common/models/dimension/dimension-group.fixtures.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DimensionGroupJS } from "./dimension-group";
+import { DimensionMock } from "./dimension.mock";
+
+export class DimensionGroupFixtures {
+  static noTitleJS(): DimensionGroupJS {
+    return {
+      name: 'dummyName',
+      dimensions: [
+        DimensionMock.wikiTimeJS()
+      ]
+    };
+  }
+
+  static withTitleInferredJS(): DimensionGroupJS {
+    return {
+      name: 'dummyName',
+      title: 'Dummy Name',
+      dimensions: [
+        DimensionMock.wikiTimeJS()
+      ]
+    };
+  }
+
+  static noNameJS(): DimensionGroupJS {
+    return {
+      dimensions: [DimensionMock.wikiTimeJS()]
+    } as DimensionGroupJS;
+  }
+
+  static noDimensionsJS(): DimensionGroupJS {
+    return {
+      name: 'dummyName'
+    } as DimensionGroupJS;
+  }
+
+  static emptyDimensionsJS(): DimensionGroupJS {
+    return {
+      name: 'dummyName',
+      dimensions: []
+    } as DimensionGroupJS;
+  }
+
+  static commentsJS(): DimensionGroupJS {
+    return {
+      name: 'comment_group',
+      title: 'Comment Group',
+      dimensions: [
+        {
+          kind: 'string',
+          name: 'comment',
+          title: 'Comment',
+          formula: '$comment'
+        },
+        {
+          kind: 'number',
+          name: 'commentLength',
+          title: 'Comment Length',
+          formula: '$commentLength'
+        },
+        {
+          kind: 'boolean',
+          name: 'commentLengthOver100',
+          title: 'Comment Length Over 100',
+          formula: '$commentLength > 100'
+        }
+      ]
+    };
+  }
+}

--- a/src/common/models/dimension/dimension-group.mocha.ts
+++ b/src/common/models/dimension/dimension-group.mocha.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+import { DimensionGroup } from "./dimension-group";
+import { DimensionGroupFixtures } from "./dimension-group.fixtures";
+
+describe("DimensionGroup", () => {
+
+  it("should convert to / from JS", () => {
+    const dimensionGroup = DimensionGroup.fromJS(DimensionGroupFixtures.commentsJS());
+
+    expect(dimensionGroup.toJS()).to.deep.equal(DimensionGroupFixtures.commentsJS());
+  });
+
+  it("should infer title from name", () => {
+    const dimensionGroup = DimensionGroup.fromJS(DimensionGroupFixtures.noTitleJS());
+
+    expect(dimensionGroup.toJS()).to.deep.equal(DimensionGroupFixtures.withTitleInferredJS());
+  });
+
+  it("should infer title from name", () => {
+    const dimensionGroup = DimensionGroup.fromJS(DimensionGroupFixtures.noTitleJS());
+
+    expect(dimensionGroup.toJS()).to.deep.equal(DimensionGroupFixtures.withTitleInferredJS());
+  });
+
+  it("should throw when no name given", () => {
+    const dimensionGroupConversion = () => DimensionGroup.fromJS(DimensionGroupFixtures.noNameJS());
+
+    expect(dimensionGroupConversion).to.throw("dimension group requires a name");
+  });
+
+  it("should throw when no dimensions given", () => {
+    const groupWithNoDimensions = DimensionGroupFixtures.noDimensionsJS();
+    const dimensionGroupConversion = () => DimensionGroup.fromJS(groupWithNoDimensions);
+
+    expect(dimensionGroupConversion).to.throw(`dimension group '${groupWithNoDimensions.name}' has no dimensions`);
+  });
+
+  it("should throw when empty dimensions given", () => {
+    const groupWithEmptyDimensions = DimensionGroupFixtures.emptyDimensionsJS();
+    const dimensionGroupConversion = () => DimensionGroup.fromJS(groupWithEmptyDimensions);
+
+    expect(dimensionGroupConversion).to.throw(`dimension group '${groupWithEmptyDimensions.name}' has no dimensions`);
+  });
+
+});

--- a/src/common/models/dimension/dimension-group.ts
+++ b/src/common/models/dimension/dimension-group.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { immutableArraysEqual, Instance } from "immutable-class";
+import { makeTitle } from "../../utils/general/general";
+import { Dimension, DimensionJS } from "./dimension";
+
+export type DimensionOrGroupJS = DimensionJS | DimensionGroupJS;
+export type DimensionOrGroup = Dimension | DimensionGroup;
+
+export interface DimensionGroupJS {
+  name: string;
+  title?: string;
+  dimensions: DimensionOrGroupJS[];
+}
+
+export interface DimensionGroupValue {
+  name: string;
+  title?: string;
+  dimensions: DimensionOrGroup[];
+}
+
+export interface DimensionOrGroupVisitor<R> {
+  visitDimension(dimension: Dimension): R;
+
+  visitDimensionGroup(dimensionGroup: DimensionGroup): R;
+}
+
+export function dimensionOrGroupFromJS(dimensionOrGroup: DimensionOrGroupJS): DimensionOrGroup {
+  if (isDimensionGroupJS(dimensionOrGroup)) {
+    return DimensionGroup.fromJS(dimensionOrGroup);
+  } else {
+    return Dimension.fromJS(dimensionOrGroup);
+  }
+}
+
+function isDimensionGroupJS(dimensionOrGroup: DimensionOrGroupJS): dimensionOrGroup is DimensionGroupJS {
+  return (dimensionOrGroup as DimensionGroupJS).dimensions !== undefined;
+}
+
+export class DimensionGroup implements Instance<DimensionGroupValue, DimensionGroupJS> {
+  static fromJS(dimensionGroup: DimensionGroupJS) {
+    const { name, title, dimensions } = dimensionGroup;
+
+    if (name == null) {
+      throw new Error(`dimension group requires a name`);
+    }
+
+    if (dimensions == null || dimensions.length === 0) {
+      throw new Error(`dimension group '${name}' has no dimensions`);
+    }
+
+    return new DimensionGroup({
+      name,
+      title,
+      dimensions: dimensions.map(dimensionOrGroupFromJS)
+    });
+  }
+
+  static isDimensionGroup(candidate: any): candidate is DimensionGroup {
+    return candidate instanceof DimensionGroup;
+  }
+
+  readonly name: string;
+  readonly title: string;
+  readonly type = "group";
+  readonly dimensions: DimensionOrGroup[];
+
+  constructor(parameters: DimensionGroupValue) {
+    this.name = parameters.name;
+    this.title = parameters.title || makeTitle(parameters.name);
+    this.dimensions = parameters.dimensions;
+  }
+
+  accept<R>(visitor: DimensionOrGroupVisitor<R>): R {
+    return visitor.visitDimensionGroup(this);
+  }
+
+  equals(other: any): boolean {
+    return this === other
+      || DimensionGroup.isDimensionGroup(other) && immutableArraysEqual(this.dimensions, other.dimensions);
+  }
+
+  toJS(): DimensionGroupJS {
+    return {
+      name: this.name,
+      title: this.title,
+      dimensions: this.dimensions.map((dimension) => dimension.toJS())
+    };
+  }
+
+  toJSON(): DimensionGroupJS {
+    return this.toJS();
+  }
+
+  valueOf(): DimensionGroupValue {
+    return {
+      name: this.name,
+      title: this.title,
+      dimensions: this.dimensions
+    };
+  }
+}

--- a/src/common/models/dimension/dimension.mocha.ts
+++ b/src/common/models/dimension/dimension.mocha.ts
@@ -18,7 +18,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { Dimension, DimensionJS } from './dimension';
+import { BucketingStrategy, Dimension, DimensionJS } from './dimension';
 
 describe('Dimension', () => {
   it('is an immutable class', () => {
@@ -47,7 +47,7 @@ describe('Dimension', () => {
           op: 'numberBucket',
           size: 1
         },
-        bucketingStrategy: 'defaultBucket'
+        bucketingStrategy: BucketingStrategy.defaultBucket
       },
       {
         name: 'time',

--- a/src/common/models/dimension/dimension.mock.ts
+++ b/src/common/models/dimension/dimension.mock.ts
@@ -55,6 +55,24 @@ export class DimensionMock {
     };
   }
 
+  static wikiTimeJS(): DimensionJS {
+    return {
+      name: 'time',
+      title: 'Time',
+      formula: '$time',
+      kind: 'time'
+    };
+  }
+
+  static wikiTime(): Dimension {
+    return new Dimension({
+      name: 'time',
+      title: 'Time',
+      formula: '$time',
+      kind: 'time'
+    });
+  }
+
   static countryString() {
     return Dimension.fromJS(DimensionMock.COUNTRY_STRING_JS);
   }

--- a/src/common/models/dimension/dimensions.fixtures.ts
+++ b/src/common/models/dimension/dimensions.fixtures.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DimensionOrGroupJS } from "./dimension-group";
+import { DimensionGroupFixtures } from "./dimension-group.fixtures";
+import { DimensionMock } from "./dimension.mock";
+
+export class DimensionsFixtures {
+  static wikiNames(): string[] {
+    return ["time", "channel", "comment", "commentLength", "commentLengthOver100", "isRobot", "namespace", "articleName", "page", "userChars"];
+  }
+
+  static wikiTitles(): string[] {
+    return ["Time", "Channel", "Comment", "Comment Length", "Comment Length Over 100", "Is Robot", "Namespace", "Article Name", "Page", "User Chars"];
+  }
+
+  static wikiJS(): DimensionOrGroupJS[] {
+    return [
+      DimensionMock.wikiTimeJS(),
+      {
+        kind: 'string',
+        name: 'channel',
+        title: 'Channel',
+        formula: '$channel'
+      },
+      DimensionGroupFixtures.commentsJS(),
+      {
+        kind: 'string',
+        name: 'isRobot',
+        title: 'Is Robot',
+        formula: '$isRobot'
+      },
+      {
+        kind: 'string',
+        name: 'namespace',
+        title: 'Namespace',
+        formula: '$namespace'
+      },
+      {
+        kind: 'string',
+        name: 'articleName',
+        title: 'Article Name',
+        formula: '$articleName'
+      },
+      {
+        kind: 'string',
+        name: 'page',
+        title: 'Page',
+        formula: '$page'
+      },
+      {
+        kind: 'string',
+        name: 'userChars',
+        title: 'User Chars',
+        formula: '$userChars'
+      }
+    ];
+  }
+
+  static twitterJS(): DimensionOrGroupJS[] {
+    return [
+      {
+        kind: 'time',
+        name: 'time',
+        title: 'Time',
+        formula: '$time'
+      },
+      {
+        kind: 'string',
+        name: 'twitterHandle',
+        title: 'Twitter Handle',
+        formula: '$twitterHandle'
+      },
+      {
+        kind: 'number',
+        name: 'tweetLength',
+        title: 'Tweet Length',
+        formula: '$tweetLength'
+      }
+    ];
+  }
+}

--- a/src/common/models/dimension/dimensions.mocha.ts
+++ b/src/common/models/dimension/dimensions.mocha.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { List } from "immutable";
+import { Expression } from "plywood";
+import { DimensionJS } from "./dimension";
+import { DimensionMock } from "./dimension.mock";
+import { Dimensions } from "./dimensions";
+import { DimensionsFixtures } from "./dimensions.fixtures";
+
+describe("Dimensions", () => {
+  let dimensions: Dimensions;
+
+  beforeEach(() => {
+    dimensions = Dimensions.fromJS(DimensionsFixtures.wikiJS());
+  });
+
+  it("should convert symmetrically to / from JS", () => {
+    expect(dimensions.toJS()).to.deep.equal(DimensionsFixtures.wikiJS());
+  });
+
+  it("should throw when converting tree with duplicate dimension names", () => {
+    const dimensionsWithDuplicateDimensionName = [DimensionMock.wikiTimeJS(), DimensionMock.wikiTimeJS()];
+    expect(() => Dimensions.fromJS(dimensionsWithDuplicateDimensionName)).to.throw("found duplicate dimension or group with names: 'time'");
+  });
+
+  it("should throw when converting tree with duplicate dimension or group names", () => {
+    const fakeDimensionWithDuplicateName: DimensionJS = { name: "comment_group", formula: "$comment_group" };
+    const dimensionsWithDuplicateDimensionName = [fakeDimensionWithDuplicateName, ...DimensionsFixtures.wikiJS()];
+    expect(() => Dimensions.fromJS(dimensionsWithDuplicateDimensionName)).to.throw("found duplicate dimension or group with names: 'comment_group'");
+  });
+
+  it("should count dimensions", () => {
+    expect(dimensions.size()).to.equal(10);
+  });
+
+  it("should return the first dimension", () => {
+    expect(dimensions.first().toJS()).to.deep.equal(DimensionMock.wikiTimeJS());
+  });
+
+  it("should treat dimensions with the same structure as equal", () => {
+    const otherDimensions = Dimensions.fromJS(DimensionsFixtures.wikiJS());
+
+    expect(dimensions.equals(otherDimensions)).to.be.true;
+  });
+
+  it("should treat dimensions with different structure as different", () => {
+    const [, ...dimensionsWithoutFirstJS] = DimensionsFixtures.wikiJS();
+    const dimensionsWithoutCount = Dimensions.fromJS(dimensionsWithoutFirstJS);
+
+    expect(dimensions.equals(dimensionsWithoutCount)).to.be.false;
+  });
+
+  it("should map dimensions", () => {
+    const dimensionNames = dimensions.mapDimensions(dimension => dimension.name);
+
+    expect(dimensionNames).to.deep.equal(DimensionsFixtures.wikiNames());
+  });
+
+  it("should filter dimensions", () => {
+    const countDimensionsJS = dimensions
+      .filterDimensions(dimension => dimension.name === "time")
+      .map(dimension => dimension.toJS());
+
+    expect(countDimensionsJS).to.deep.equal([DimensionMock.wikiTimeJS()]);
+  });
+
+  it("should traverse dimensions", () => {
+    let dimensionTitles: string[] = [];
+    dimensions.forEachDimension(dimension => dimensionTitles.push(dimension.title));
+
+    expect(dimensionTitles).to.deep.equal(DimensionsFixtures.wikiTitles());
+  });
+
+  it("should find dimension by name", () => {
+    const dimension = dimensions.getDimensionByName("time");
+
+    expect(dimension.toJS()).to.deep.equal(DimensionMock.wikiTimeJS());
+  });
+
+  it("should find dimension by expression", () => {
+    const dimension = dimensions.getDimensionByExpression(Expression.fromJSLoose("$time"));
+
+    expect(dimension.toJS()).to.deep.equal(DimensionMock.wikiTimeJS());
+  });
+
+  it("should know it contains dimension with name", () => {
+    expect(dimensions.containsDimensionWithName("time")).to.be.true;
+  });
+
+  it("should provide dimension names", () => {
+    const dimensionNames = dimensions.getDimensionNames();
+
+    expect(dimensionNames).to.deep.equal(List(DimensionsFixtures.wikiNames()));
+  });
+
+  it("should be immutable on append", () => {
+    const newDimensions = dimensions.append(DimensionMock.countryString());
+
+    expect(dimensions.size()).to.equal(10);
+    expect(newDimensions).to.not.equal(dimensions);
+    expect(newDimensions.equals(dimensions)).to.be.false;
+    expect(newDimensions.size()).to.equal(11);
+  });
+
+  it("should be immutable on prepend", () => {
+    const newDimensions = dimensions.prepend(DimensionMock.countryString());
+
+    expect(dimensions.size()).to.equal(10);
+    expect(newDimensions).to.not.equal(dimensions);
+    expect(newDimensions.equals(dimensions)).to.be.false;
+    expect(newDimensions.size()).to.equal(11);
+  });
+});

--- a/src/common/models/dimension/dimensions.ts
+++ b/src/common/models/dimension/dimensions.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { List } from "immutable";
+import { immutableArraysEqual } from "immutable-class";
+import { Expression } from "plywood";
+import { quoteNames } from "../../utils/general/general";
+import { Dimension } from "./dimension";
+import { DimensionGroup, DimensionOrGroup, dimensionOrGroupFromJS, DimensionOrGroupJS, DimensionOrGroupVisitor } from "./dimension-group";
+
+class FlattenDimensionsWithGroupsVisitor implements DimensionOrGroupVisitor<void> {
+  private items = List<DimensionOrGroup>().asMutable();
+
+  visitDimension(dimension: Dimension): void {
+    this.items.push(dimension);
+  }
+
+  visitDimensionGroup(dimensionGroup: DimensionGroup): void {
+    this.items.push(dimensionGroup);
+    dimensionGroup.dimensions.forEach(dimensionOrGroup => dimensionOrGroup.accept(this));
+  }
+
+  getDimensionsWithGroups(): List<DimensionOrGroup> {
+    return this.items.toList();
+  }
+}
+
+function findDuplicateNames(items: List<DimensionOrGroup>): List<string> {
+  return items
+    .groupBy((dimension) => dimension.name)
+    .filter((names) => names.size > 1)
+    .map((names, name) => name)
+    .toList();
+}
+
+function filterDimensions(items: List<DimensionOrGroup>): List<Dimension> {
+  return List<Dimension> (items
+    .filter((item) => item.type === "dimension")
+    .toList()
+  );
+}
+
+export class Dimensions {
+  static empty(): Dimensions {
+    return new Dimensions([]);
+  }
+
+  static fromJS(parameters: DimensionOrGroupJS[]): Dimensions {
+    return new Dimensions(parameters.map(dimensionOrGroupFromJS));
+  }
+
+  private readonly dimensions: DimensionOrGroup[];
+  private readonly flattenedDimensions: List<Dimension>;
+
+  private constructor(dimensions: DimensionOrGroup[]) {
+    this.dimensions = [...dimensions];
+
+    const flattenDimensionsWithGroupsVisitor = new FlattenDimensionsWithGroupsVisitor();
+    this.dimensions.forEach(dimensionOrGroup => dimensionOrGroup.accept(flattenDimensionsWithGroupsVisitor));
+    const flattenedDimensionsWithGroups = flattenDimensionsWithGroupsVisitor.getDimensionsWithGroups();
+    const duplicateNames = findDuplicateNames(flattenedDimensionsWithGroups);
+
+    if (duplicateNames.size > 0) {
+      throw new Error(`found duplicate dimension or group with names: ${quoteNames(duplicateNames)}`);
+    }
+
+    this.flattenedDimensions = filterDimensions(flattenedDimensionsWithGroups);
+  }
+
+  accept<R>(visitor: DimensionOrGroupVisitor<R>): R[] {
+    return this.dimensions.map((dimensionOrGroup) => dimensionOrGroup.accept(visitor));
+  }
+
+  size(): number {
+    return this.flattenedDimensions.size;
+  }
+
+  first(): Dimension {
+    return this.flattenedDimensions.first();
+  }
+
+  equals(other: Dimensions): boolean {
+    return this === other || immutableArraysEqual(this.dimensions, other.dimensions);
+  }
+
+  mapDimensions<R>(mapper: (dimension: Dimension) => R): Array<R> {
+    return this.flattenedDimensions.map(mapper).toArray();
+  }
+
+  filterDimensions(predicate: (dimension: Dimension) => boolean): Array<Dimension> {
+    return this.flattenedDimensions.filter(predicate).toArray();
+  }
+
+  forEachDimension(sideEffect: (dimension: Dimension) => void): void {
+    this.flattenedDimensions.forEach(sideEffect);
+  }
+
+  getDimensionByName(name: string): Dimension {
+    return this.flattenedDimensions.find((dimension) => dimension.name === name);
+  }
+
+  getDimensionByExpression(expression: Expression): Dimension {
+    return this.flattenedDimensions.find((dimension) => expression.equals(dimension.expression));
+  }
+
+  getDimensionNames(): List<string> {
+    return this.flattenedDimensions.map((dimension) => dimension.name).toList();
+  }
+
+  containsDimensionWithName(name: string) {
+    return this.flattenedDimensions.some((dimension) => dimension.name === name);
+  }
+
+  append(...dimensions: Array<Dimension>) {
+    return new Dimensions([...this.dimensions, ...dimensions]);
+  }
+
+  prepend(...dimensions: Array<Dimension>) {
+    return new Dimensions([...dimensions, ...this.dimensions]);
+  }
+
+  toJS(): DimensionOrGroupJS[] {
+    return this.dimensions.map((dimensionOrGroup) => dimensionOrGroup.toJS());
+  }
+}

--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -688,7 +688,7 @@ export class Essence implements Instance<EssenceValue, EssenceJS> {
         value.singleMeasure = selectedMeasures.first();
       }
     } else {
-      value.selectedMeasures = addToSetInOrder(dataCube.measures.map(m => m.name), value.selectedMeasures, singleMeasure);
+      value.selectedMeasures = addToSetInOrder(dataCube.measures.getMeasureNames(), value.selectedMeasures, singleMeasure);
     }
     return new Essence(value);
   }
@@ -711,7 +711,7 @@ export class Essence implements Instance<EssenceValue, EssenceJS> {
     if (selectedMeasures.has(measureName)) {
       value.selectedMeasures = selectedMeasures.delete(measureName);
     } else {
-      value.selectedMeasures = addToSetInOrder(dataCube.measures.map(m => m.name), selectedMeasures, measureName);
+      value.selectedMeasures = addToSetInOrder(dataCube.measures.getMeasureNames(), selectedMeasures, measureName);
     }
 
     return new Essence(value);

--- a/src/common/models/filter/filter.ts
+++ b/src/common/models/filter/filter.ts
@@ -24,6 +24,7 @@ import {
 } from 'plywood';
 import { immutableListsEqual } from '../../utils/general/general';
 import { Dimension } from '../dimension/dimension';
+import { Dimensions } from "../dimension/dimensions";
 import { FilterClause, FilterClauseJS, FilterSelection } from '../filter-clause/filter-clause';
 
 function withholdClause(clauses: List<FilterClause>, clause: FilterClause, allowIndex: number): List<FilterClause> {
@@ -331,12 +332,12 @@ export class Filter implements Instance<FilterValue, FilterJS> {
     return clauses.get(0).getLiteralSet();
   }
 
-  public constrainToDimensions(dimensions: List<Dimension>, timeAttribute: Expression, oldTimeAttribute: Expression = null): Filter {
+  public constrainToDimensions(dimensions: Dimensions, timeAttribute: Expression, oldTimeAttribute: Expression = null): Filter {
     var hasChanged = false;
     var clauses: FilterClause[] = [];
     this.clauses.forEach((clause) => {
       var clauseExpression = clause.expression;
-      if (Dimension.getDimensionByExpression(dimensions, clauseExpression)) {
+      if (dimensions.getDimensionByExpression(clauseExpression)) {
         clauses.push(clause);
       } else {
         hasChanged = true;

--- a/src/common/models/highlight/highlight.ts
+++ b/src/common/models/highlight/highlight.ts
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-import { List } from 'immutable';
-import { Class, Instance, immutableArraysEqual } from 'immutable-class';
-import { $, Expression } from 'plywood';
-import { Dimension } from '../dimension/dimension';
+import { Class, Instance } from 'immutable-class';
+import { Expression } from 'plywood';
+import { Dimensions } from "../dimension/dimensions";
 import { Filter, FilterJS } from '../filter/filter';
 
 export interface HighlightValue {
@@ -97,7 +96,7 @@ export class Highlight implements Instance<HighlightValue, HighlightJS> {
     return filter.applyDelta(this.delta);
   }
 
-  public constrainToDimensions(dimensions: List<Dimension>, timeAttribute: Expression): Highlight {
+  public constrainToDimensions(dimensions: Dimensions, timeAttribute: Expression): Highlight {
     var { delta } = this;
     var newDelta = delta.constrainToDimensions(dimensions, timeAttribute);
     if (newDelta === delta) return this;

--- a/src/common/models/measure/measure-group.fixtures.ts
+++ b/src/common/models/measure/measure-group.fixtures.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MeasureGroupJS } from "./measure-group";
+import { MeasureFixtures } from "./measure.fixtures";
+
+export class MeasureGroupFixtures {
+  static noTitleJS(): MeasureGroupJS {
+    return {
+      name: 'dummyName',
+      measures: [
+        MeasureFixtures.wikiCountJS()
+      ]
+    };
+  }
+
+  static withTitleInferredJS(): MeasureGroupJS {
+    return {
+      name: 'dummyName',
+      title: 'Dummy Name',
+      measures: [
+        MeasureFixtures.wikiCountJS()
+      ]
+    };
+  }
+
+  static noNameJS(): MeasureGroupJS {
+    return {
+      measures: [MeasureFixtures.wikiCountJS()]
+    } as MeasureGroupJS;
+  }
+
+  static noMeasuresJS(): MeasureGroupJS {
+    return {
+      name: 'dummyName'
+    } as MeasureGroupJS;
+  }
+
+  static emptyMeasuresJS(): MeasureGroupJS {
+    return {
+      name: 'dummyName',
+      measures: []
+    } as MeasureGroupJS;
+  }
+
+  static wikiAddedJS(): MeasureGroupJS {
+    return {
+      name: 'added_group',
+      title: 'Added Group',
+      measures: [
+        {
+          name: 'added',
+          title: 'Added',
+          formula: '$main.sum($added)'
+        },
+        {
+          name: 'avg_added',
+          title: 'Avg Added',
+          formula: '$main.average($added)'
+        }
+      ]
+    };
+  }
+
+  static wikiDeltaJS(): MeasureGroupJS {
+    return {
+      name: 'delta_group',
+      title: 'Delta Group',
+      measures: [
+        {
+          name: 'delta',
+          title: 'Delta',
+          formula: '$main.sum($delta)'
+        },
+        {
+          name: 'avg_delta',
+          title: 'Avg Delta',
+          formula: '$main.average($delta)'
+        }
+      ]
+    };
+  }
+}

--- a/src/common/models/measure/measure-group.mocha.ts
+++ b/src/common/models/measure/measure-group.mocha.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+import { MeasureGroup } from "./measure-group";
+import { MeasureGroupFixtures } from "./measure-group.fixtures";
+
+describe("MeasureGroup", () => {
+
+  it("should convert to / from JS", () => {
+    const measureGroup = MeasureGroup.fromJS(MeasureGroupFixtures.wikiAddedJS());
+
+    expect(measureGroup.toJS()).to.deep.equal(MeasureGroupFixtures.wikiAddedJS());
+  });
+
+  it("should infer title from name", () => {
+    const measureGroup = MeasureGroup.fromJS(MeasureGroupFixtures.noTitleJS());
+
+    expect(measureGroup.toJS()).to.deep.equal(MeasureGroupFixtures.withTitleInferredJS());
+  });
+
+  it("should infer title from name", () => {
+    const measureGroup = MeasureGroup.fromJS(MeasureGroupFixtures.noTitleJS());
+
+    expect(measureGroup.toJS()).to.deep.equal(MeasureGroupFixtures.withTitleInferredJS());
+  });
+
+  it("should throw when no name given", () => {
+    const measureGroupConversion = () => MeasureGroup.fromJS(MeasureGroupFixtures.noNameJS());
+
+    expect(measureGroupConversion).to.throw("measure group requires a name");
+  });
+
+  it("should throw when no measures given", () => {
+    const groupWithNoMeasures = MeasureGroupFixtures.noMeasuresJS();
+    const measureGroupConversion = () => MeasureGroup.fromJS(groupWithNoMeasures);
+
+    expect(measureGroupConversion).to.throw(`measure group '${groupWithNoMeasures.name}' has no measures`);
+  });
+
+  it("should throw when empty measures given", () => {
+    const groupWithEmptyMeasures = MeasureGroupFixtures.emptyMeasuresJS();
+    const measureGroupConversion = () => MeasureGroup.fromJS(groupWithEmptyMeasures);
+
+    expect(measureGroupConversion).to.throw(`measure group '${groupWithEmptyMeasures.name}' has no measures`);
+  });
+
+});

--- a/src/common/models/measure/measure-group.ts
+++ b/src/common/models/measure/measure-group.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { immutableArraysEqual, Instance } from "immutable-class";
+import { makeTitle } from "../../utils/general/general";
+import { Measure, MeasureJS } from "./measure";
+
+export type MeasureOrGroupJS = MeasureJS | MeasureGroupJS;
+export type MeasureOrGroup = Measure | MeasureGroup;
+
+export interface MeasureGroupJS {
+  name: string;
+  title?: string;
+  measures: MeasureOrGroupJS[];
+}
+
+export interface MeasureGroupValue {
+  name: string;
+  title?: string;
+  measures: MeasureOrGroup[];
+}
+
+export interface MeasureOrGroupVisitor<R> {
+  visitMeasure(measure: Measure): R;
+
+  visitMeasureGroup(measureGroup: MeasureGroup): R;
+}
+
+export function measureOrGroupFromJS(measureOrGroup: MeasureOrGroupJS): MeasureOrGroup {
+  if (isMeasureGroupJS(measureOrGroup)) {
+    return MeasureGroup.fromJS(measureOrGroup);
+  } else {
+    return Measure.fromJS(measureOrGroup);
+  }
+}
+
+function isMeasureGroupJS(measureOrGroupJS: MeasureOrGroupJS): measureOrGroupJS is MeasureGroupJS {
+  return (measureOrGroupJS as MeasureGroupJS).measures !== undefined;
+}
+
+export class MeasureGroup implements Instance<MeasureGroupValue, MeasureGroupJS> {
+  static fromJS(parameters: MeasureGroupJS): MeasureGroup {
+    const { name, title, measures } = parameters;
+
+    if (name == null) {
+      throw new Error("measure group requires a name");
+    }
+
+    if (measures == null || measures.length === 0) {
+      throw new Error(`measure group '${name}' has no measures`);
+    }
+
+    return new MeasureGroup({
+      name,
+      title,
+      measures: measures.map(measureOrGroupFromJS)
+    });
+  }
+
+  static isMeasureGroup(candidate: any): candidate is MeasureGroup {
+    return candidate instanceof MeasureGroup;
+  }
+
+  readonly name: string;
+  readonly title: string;
+  readonly type = "group";
+  readonly measures: MeasureOrGroup[];
+
+  constructor(parameters: MeasureGroupValue) {
+    this.name = parameters.name;
+    this.title = parameters.title || makeTitle(parameters.name);
+    this.measures = parameters.measures;
+  }
+
+  accept<R>(visitor: MeasureOrGroupVisitor<R>): R {
+    return visitor.visitMeasureGroup(this);
+  }
+
+  equals(other: any): boolean {
+    return this === other
+      || MeasureGroup.isMeasureGroup(other) && immutableArraysEqual(this.measures, other.measures);
+  }
+
+  toJS(): MeasureGroupJS {
+    return {
+      name: this.name,
+      measures: this.measures.map(measure => measure.toJS()),
+      title: this.title
+    };
+  }
+
+  toJSON(): MeasureGroupJS {
+    return this.toJS();
+  }
+
+  valueOf(): MeasureGroupValue {
+    return {
+      name: this.name ,
+      title: this.title,
+      measures: this.measures
+    };
+  }
+}

--- a/src/common/models/measure/measure.fixtures.ts
+++ b/src/common/models/measure/measure.fixtures.ts
@@ -15,9 +15,41 @@
  */
 
 import { ExpressionJS } from "plywood";
-import { Measure } from "./measure";
+import { Measure, MeasureJS } from "./measure";
 
 export class MeasureFixtures {
+  static wikiCountJS(): MeasureJS {
+    return {
+      name: "count",
+      title: "Count",
+      formula: "$main.sum($count)"
+    };
+  }
+
+  static wikiCount(): Measure {
+    return new Measure({
+      name: "count",
+      title: "Count",
+      formula: "$main.sum($count)"
+    });
+  }
+
+  static wikiUniqueUsersJS(): MeasureJS {
+    return {
+      name: "unique_users",
+      title: "Unique Users",
+      formula: "$main.countDistinct($unique_users)"
+    };
+  }
+
+  static wikiUniqueUsers(): Measure {
+    return new Measure({
+      name: "unique_users",
+      title: "Unique Users",
+      formula: "$main.countDistinct($unique_users)"
+    });
+  }
+
   static twitterCount(): Measure {
     return Measure.fromJS({
       name: "count",

--- a/src/common/models/measure/measures.fixtures.ts
+++ b/src/common/models/measure/measures.fixtures.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MeasureOrGroupJS } from "./measure-group";
+import { MeasureGroupFixtures } from "./measure-group.fixtures";
+import { MeasureFixtures } from "./measure.fixtures";
+
+export class MeasuresFixtures {
+  static wikiNames(): string[] {
+    return ["count", "added", "avg_added", "delta", "avg_delta"];
+  }
+
+  static wikiTitles(): string[] {
+    return ["Count", "Added", "Avg Added", "Delta", "Avg Delta"];
+  }
+
+  static wikiJS(): MeasureOrGroupJS[] {
+    return [
+      MeasureFixtures.wikiCountJS(),
+      {
+        name: 'other',
+        title: 'Other',
+        measures: [
+          MeasureGroupFixtures.wikiAddedJS(),
+          MeasureGroupFixtures.wikiDeltaJS()
+        ]
+      }
+    ];
+  }
+
+  static twitterJS(): MeasureOrGroupJS[] {
+    return [
+      {
+        name: 'count',
+        title: 'count',
+        formula: '$main.count()'
+      }
+    ];
+  }
+}

--- a/src/common/models/measure/measures.mocha.ts
+++ b/src/common/models/measure/measures.mocha.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { List, OrderedSet } from "immutable";
+import { Expression } from "plywood";
+import { MeasureJS } from "./measure";
+import { MeasureFixtures } from "./measure.fixtures";
+import { Measures } from "./measures";
+import { MeasuresFixtures } from "./measures.fixtures";
+
+describe("Measures", () => {
+  let measures: Measures;
+
+  beforeEach(() => {
+    measures = Measures.fromJS(MeasuresFixtures.wikiJS());
+  });
+
+  it("should convert symmetrically to / from JS", () => {
+    expect(measures.toJS()).to.deep.equal(MeasuresFixtures.wikiJS());
+  });
+
+  it("should throw when converting tree with duplicate measure names", () => {
+    const measuresWithDuplicateMeasureName = [MeasureFixtures.wikiCountJS(), MeasureFixtures.wikiCountJS()];
+    expect(() => Measures.fromJS(measuresWithDuplicateMeasureName)).to.throw("found duplicate measure or group with names: 'count'");
+  });
+
+  it("should throw when converting tree with duplicate measure or group names", () => {
+    const fakeMeasureWithDuplicateName: MeasureJS = { name: "added_group", formula: "$main.sum($count)" };
+    const measuresWithDuplicateMeasureName = [fakeMeasureWithDuplicateName, ...MeasuresFixtures.wikiJS()];
+    expect(() => Measures.fromJS(measuresWithDuplicateMeasureName)).to.throw("found duplicate measure or group with names: 'added_group'");
+  });
+
+  it("should count measures", () => {
+    expect(measures.size()).to.equal(5);
+  });
+
+  it("should return the first measure", () => {
+    expect(measures.first().toJS()).to.deep.equal(MeasureFixtures.wikiCountJS());
+  });
+
+  it("should treat measures with the same structure as equal", () => {
+    const otherMeasures = Measures.fromJS(MeasuresFixtures.wikiJS());
+
+    expect(measures.equals(otherMeasures)).to.be.true;
+  });
+
+  it("should treat measures with different structure as different", () => {
+    const [, ...measuresWithoutFirstJS] = MeasuresFixtures.wikiJS();
+    const measuresWithoutCount = Measures.fromJS(measuresWithoutFirstJS);
+
+    expect(measures.equals(measuresWithoutCount)).to.be.false;
+  });
+
+  it("should map measures", () => {
+    const measureNames = measures.mapMeasures(measure => measure.name);
+
+    expect(measureNames).to.deep.equal(MeasuresFixtures.wikiNames());
+  });
+
+  it("should filter measures", () => {
+    const countMeasuresJS = measures
+      .filterMeasures(measure => measure.name === "count")
+      .map(measure => measure.toJS());
+
+    expect(countMeasuresJS).to.deep.equal([MeasureFixtures.wikiCountJS()]);
+  });
+
+  it("should traverse measures", () => {
+    let measureTitles: string[] = [];
+    measures.forEachMeasure(measure => measureTitles.push(measure.title));
+
+    expect(measureTitles).to.deep.equal(MeasuresFixtures.wikiTitles());
+  });
+
+  it("should find measure by name", () => {
+    const measure = measures.getMeasureByName("count");
+
+    expect(measure.toJS()).to.deep.equal(MeasureFixtures.wikiCountJS());
+  });
+
+  it("should find measure by expression", () => {
+    const measure = measures.getMeasureByExpression(Expression.fromJSLoose("$main.sum($count)"));
+
+    expect(measure.toJS()).to.deep.equal(MeasureFixtures.wikiCountJS());
+  });
+
+  it("should know it contains measure with name", () => {
+    expect(measures.containsMeasureWithName("count")).to.be.true;
+  });
+
+  it("should provide measure names", () => {
+    const measureNames = measures.getMeasureNames();
+
+    expect(measureNames).to.deep.equal(List(MeasuresFixtures.wikiNames()));
+  });
+
+  it("should provide first n measure names", () => {
+    const measureNames = measures.getFirstNMeasureNames(1);
+
+    expect(measureNames).to.deep.equal(OrderedSet(["count"]));
+  });
+
+  it("should be immutable on append", () => {
+    const newMeasures = measures.append(MeasureFixtures.wikiUniqueUsers());
+
+    expect(measures.size()).to.equal(5);
+    expect(newMeasures).to.not.equal(measures);
+    expect(newMeasures.equals(measures)).to.be.false;
+    expect(newMeasures.size()).to.equal(6);
+  });
+
+  it("should be immutable on prepend", () => {
+    const newMeasures = measures.prepend(MeasureFixtures.wikiUniqueUsers());
+
+    expect(measures.size()).to.equal(5);
+    expect(newMeasures).to.not.equal(measures);
+    expect(newMeasures.equals(measures)).to.be.false;
+    expect(newMeasures.size()).to.equal(6);
+  });
+});

--- a/src/common/models/measure/measures.ts
+++ b/src/common/models/measure/measures.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015-2016 Imply Data, Inc.
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { List, OrderedSet } from "immutable";
+import { immutableArraysEqual } from "immutable-class";
+import { Expression } from "plywood";
+import { quoteNames } from "../../utils/general/general";
+import { Measure } from "./measure";
+import { MeasureGroup, MeasureOrGroup, measureOrGroupFromJS, MeasureOrGroupJS, MeasureOrGroupVisitor } from "./measure-group";
+
+class FlattenMeasuresWithGroupsVisitor implements MeasureOrGroupVisitor<void> {
+  private items = List<MeasureOrGroup>().asMutable();
+
+  visitMeasure(measure: Measure): void {
+    this.items.push(measure);
+  }
+
+  visitMeasureGroup(measureGroup: MeasureGroup): void {
+    this.items.push(measureGroup);
+    measureGroup.measures.forEach(measureOrGroup => measureOrGroup.accept(this));
+  }
+
+  getMeasuresAndGroups(): List<MeasureOrGroup> {
+    return this.items.toList();
+  }
+}
+
+function findDuplicateNames(items: List<MeasureOrGroup>): List<string> {
+  return items
+    .groupBy((measure) => measure.name)
+    .filter((names) => names.size > 1)
+    .map((names, name) => name)
+    .toList();
+}
+
+function filterMeasures(items: List<MeasureOrGroup>): List<Measure> {
+  return List<Measure> (items
+    .filter((item) => item.type === "measure")
+    .toList());
+}
+
+export class Measures {
+  static empty(): Measures {
+    return new Measures([]);
+  }
+
+  static fromJS(parameters: MeasureOrGroupJS[]): Measures {
+    return new Measures(parameters.map(measureOrGroupFromJS));
+  }
+
+  private readonly measures: MeasureOrGroup[];
+  private readonly flattenedMeasures: List<Measure>;
+
+  private constructor(measures: MeasureOrGroup[]) {
+    this.measures = [...measures];
+
+    const duplicateNamesFindingVisitor = new FlattenMeasuresWithGroupsVisitor();
+    this.measures.forEach(measureOrGroup => measureOrGroup.accept(duplicateNamesFindingVisitor));
+    const flattenedMeasuresWithGroups = duplicateNamesFindingVisitor.getMeasuresAndGroups();
+    const duplicateNames = findDuplicateNames(flattenedMeasuresWithGroups);
+
+    if (duplicateNames.size > 0) {
+      throw new Error(`found duplicate measure or group with names: ${quoteNames(duplicateNames)}`);
+    }
+
+    this.flattenedMeasures = filterMeasures(flattenedMeasuresWithGroups);
+  }
+
+  accept<R>(visitor: MeasureOrGroupVisitor<R>): R[] {
+    return this.measures.map(measureOrGroup => measureOrGroup.accept(visitor));
+  }
+
+  size(): int {
+    return this.flattenedMeasures.size;
+  }
+
+  first(): Measure {
+    return this.flattenedMeasures.first();
+  }
+
+  equals(other: Measures): boolean {
+    return this === other || immutableArraysEqual(this.measures, other.measures);
+  }
+
+  mapMeasures<R>(mapper: (measure: Measure) => R): Array<R> {
+    return this.flattenedMeasures.map(mapper).toArray();
+  }
+
+  filterMeasures(predicate: (dimension: Measure) => boolean): Array<Measure> {
+    return this.flattenedMeasures.filter(predicate).toArray();
+  }
+
+  forEachMeasure(sideEffect: (measure: Measure) => void): void {
+    this.flattenedMeasures.forEach(sideEffect);
+  }
+
+  getMeasureByName(measureName: string): Measure {
+    return this.flattenedMeasures.find((measure) => measure.name === measureName);
+  }
+
+  getMeasureByExpression(expression: Expression): Measure {
+    return this.flattenedMeasures.find((measure) => measure.expression.equals(expression));
+  }
+
+  getMeasureNames(): List<string> {
+    return this.flattenedMeasures.map((measure) => measure.name).toList();
+  }
+
+  containsMeasureWithName(name: string): boolean {
+    return this.flattenedMeasures.some((measure) => measure.name === name);
+  }
+
+  getFirstNMeasureNames(n: number): OrderedSet<string> {
+    return OrderedSet(this.flattenedMeasures.slice(0, n).map((measure) => measure.name));
+  }
+
+  append(...measures: Array<Measure>): Measures {
+    return new Measures([...this.measures, ...measures]);
+  }
+
+  prepend(...measures: Array<Measure>): Measures {
+    return new Measures([...measures, ...this.measures]);
+  }
+
+  toJS(): MeasureOrGroupJS[] {
+    return this.measures.map((measure) => measure.toJS());
+  }
+}

--- a/src/common/utils/general/general.ts
+++ b/src/common/utils/general/general.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { List } from 'immutable';
+import { Collection, List } from 'immutable';
 import { immutableArraysEqual, Equalable } from 'immutable-class';
 import { TimeRange, NumberRange, PlywoodRange } from 'plywood';
 
@@ -149,4 +149,8 @@ export function ensureOneOf(value: string, values: string[], messagePrefix: stri
 
 export function pluralIfNeeded(n: number, thing: string): string {
   return `${n} ${thing}${n === 1 ? '' : 's'}`;
+}
+
+export function quoteNames(names: Collection.Indexed<string>): string {
+  return names.map(name => `'${name}'`).join(", ");
 }

--- a/src/common/utils/rules/resolutions.ts
+++ b/src/common/utils/rules/resolutions.ts
@@ -19,12 +19,16 @@ import { DataCube, Resolution, SplitCombine, Splits } from "../../models";
 
 export class Resolutions {
   static someDimensions = (dataCube: DataCube): Resolution[] => {
-    const dimensions = dataCube.getDimensionsByKind("string").slice(0, 2);
-    return dimensions.map((someDimension) => {
+    const numberOfSuggestedSplitDimensions = 2;
+    const suggestedSplitDimensions = dataCube
+      .getDimensionsByKind("string")
+      .slice(0, numberOfSuggestedSplitDimensions);
+
+    return suggestedSplitDimensions.map((dimension) => {
       return {
-        description: `Add a split on ${someDimension.title}`,
+        description: `Add a split on ${dimension.title}`,
         adjustment: {
-          splits: Splits.fromSplitCombine(SplitCombine.fromExpression(someDimension.expression))
+          splits: Splits.fromSplitCombine(SplitCombine.fromExpression(dimension.expression))
         }
       };
     });

--- a/src/common/utils/rules/resolutions.ts
+++ b/src/common/utils/rules/resolutions.ts
@@ -19,7 +19,7 @@ import { DataCube, Resolution, SplitCombine, Splits } from "../../models";
 
 export class Resolutions {
   static someDimensions = (dataCube: DataCube): Resolution[] => {
-    const dimensions = dataCube.dimensions.toArray().filter(d => d.kind === 'string').slice(0, 2);
+    const dimensions = dataCube.getDimensionsByKind("string").slice(0, 2);
     return dimensions.map((someDimension) => {
       return {
         description: `Add a split on ${someDimension.title}`,
@@ -43,7 +43,7 @@ export class Resolutions {
   }
 
   static firstMeasure = (dataCube: DataCube): Resolution[] => {
-    const firstMeasure = dataCube.measures.get(0);
+    const firstMeasure = dataCube.measures.first();
     return [{ description: `Select measure: ${firstMeasure.title}`, adjustment: { selectedMeasures: [firstMeasure] } }];
   }
 }

--- a/src/common/utils/url-hash-converter/url-hash-converter.fixtures.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.fixtures.ts
@@ -64,6 +64,7 @@ export class UrlHashConverterFixtures {
       "dT5wvgASTsBKGCTVtSkWGcOjfAnKql5pWlZZtkK5wPkihUxiXOOLwBRKEETMYgwG0lIAushgJC5EzkRkYBQoMcAQGC4M7XcvhAABaMBivbLrJRYCinPhiJ" +
       "S6DBFDAAl5vD7IBguMhkLE4vHY3FAA==";
   }
+
   static noSlashInEncodedDefinition3() {
     return "3/N4IgbglgzgrghgGwgLzgFwgewHYgFwhLYCmAtAMYAWcATmiADQgYC2xyOx+IAomuQHoAqgBUAwoxAAzCAjTEaUfAG1QaAJ4AHLgVZcmNYlO57Je" +
       "gAoKsAEyV5VIazBrosuAuYCMAETNadhOjEUPRMIcSa+KSeAL4AuvFhmkhodg4a2iYQbJLW2cTYUG5ZOUwA5i7YMAi0EBrc5iKeABKSUJh0+KCGxrr5uRCG" +

--- a/src/common/utils/yaml-helper/yaml-helper.ts
+++ b/src/common/utils/yaml-helper/yaml-helper.ts
@@ -333,7 +333,6 @@ export function dataCubeToYAML(dataCube: DataCube, withComments: boolean): strin
   lines = lines.concat.apply(lines, attributeOverrides.map(attributeToYAML));
 
 
-  var dimensions = dataCube.dimensions.toArray();
   if (withComments) {
     lines.push('', "# The list of dimensions defined in the UI. The order here will be reflected in the UI");
   }
@@ -362,7 +361,7 @@ export function dataCubeToYAML(dataCube: DataCube, withComments: boolean): strin
       ""
     );
   }
-  lines = lines.concat.apply(lines, dimensions.map(dimensionToYAML));
+  lines = lines.concat.apply(lines, dataCube.dimensions.mapDimensions(dimensionToYAML));
   if (withComments) {
     lines.push(
       "  # This is the place where you might want to add derived dimensions.",
@@ -380,7 +379,6 @@ export function dataCubeToYAML(dataCube: DataCube, withComments: boolean): strin
   }
 
 
-  var measures = dataCube.measures.toArray();
   if (withComments) {
     lines.push('', "# The list of measures defined in the UI. The order here will be reflected in the UI");
   }
@@ -402,7 +400,7 @@ export function dataCubeToYAML(dataCube: DataCube, withComments: boolean): strin
       ""
     );
   }
-  lines = lines.concat.apply(lines, measures.map(measureToYAML));
+  lines = lines.concat.apply(lines, dataCube.measures.mapMeasures(measureToYAML));
   if (withComments) {
     lines.push(
       "  # This is the place where you might want to add derived measures (a.k.a Post Aggregators).",

--- a/tslint.json
+++ b/tslint.json
@@ -42,7 +42,7 @@
       "trace"
     ],
     "no-construct": false,
-    "no-parameter-properties": true,
+    "no-parameter-properties": false,
     "no-debugger": true,
     "no-duplicate-variable": false,
     "no-empty": false,


### PR DESCRIPTION
Groups are implemented as recursive arrays of either an item or group. This allows to not have a hard limit on nesting levels but also contributes to the complexity of the solution.

Dimensions and measures trees are wrapped in a corresponding wrapper objects (`Dimensions` or `Measures`) which allow querying and manipulation of the trees in a similar manner that arrays of corresponding elements could be used before.
Manipulation is currently limited to the first level only but may be extended in the future if needed.

Each tree is used in corresponding tiles to build the components structure for displaying a tree.
Initial rendering presents groups with those open which contain measures selected in visualisation or dimensions used in either filter or split. When the search is invoked all groups which leaves contain a search text in a title are open with all the other groups and leaves being hidden. Visual state of groups is not preserved in the url - it is rendered according to the above mentioned rules during initial request processing.

Documentation of configuration changes will follow shortly.

Fixes #18