### PR TITLE
Overflow hides after selecting tile

### DIFF
--- a/src/client/components/filter-tile/filter-tile.tsx
+++ b/src/client/components/filter-tile/filter-tile.tsx
@@ -132,6 +132,7 @@ export class FilterTile extends React.Component<FilterTileProps, FilterTileState
   clickDimension(dimension: Dimension, e: React.MouseEvent<HTMLElement>) {
     const target = findParentWithClass(e.target as Element, FILTER_CLASS_NAME);
     this.toggleMenu(dimension, target);
+    e.stopPropagation();
   }
 
   openMenuOnDimension(dimension: Dimension) {

--- a/src/client/components/series-tile/series-tile.tsx
+++ b/src/client/components/series-tile/series-tile.tsx
@@ -143,6 +143,7 @@ export class SeriesTile extends React.Component<SeriesTileProps, SeriesTileState
   selectSeries = (series: Series, e: React.MouseEvent<HTMLElement>) => {
     const target = findParentWithClass(e.target as Element, SERIES_CLASS_NAME);
     this.toggleMenu(series, target);
+    e.stopPropagation();
   }
 
   removeSeries = (series: Series, e: React.MouseEvent<HTMLElement>) => {

--- a/src/client/components/split-tile/split-tile.tsx
+++ b/src/client/components/split-tile/split-tile.tsx
@@ -95,6 +95,7 @@ export class SplitTile extends React.Component<SplitTileProps, SplitTileState> {
   selectDimensionSplit = (dimension: Dimension, split: Split, e: React.MouseEvent<HTMLElement>) => {
     const target = findParentWithClass(e.target as Element, SPLIT_CLASS_NAME);
     this.toggleMenu(dimension, split, target);
+    e.stopPropagation();
   }
 
   toggleMenu(dimension: Dimension, split: Split, target: Element) {


### PR DESCRIPTION
Don't bubble event after selecting tile in overflow to prevent closing overflow.