### PR TITLE
Fallback to 0 if percentage resolves to null

### DIFF
--- a/src/common/models/expression/percent.ts
+++ b/src/common/models/expression/percent.ts
@@ -65,7 +65,7 @@ export class ConcretePercentExpression implements ConcreteExpression {
     return new ApplyExpression({
       name,
       operand: new ApplyExpression({ expression, name: formulaName }),
-      expression: $(formulaName).divide($(formulaName, relativeNesting))
+      expression: $(formulaName).divide($(formulaName, relativeNesting)).fallback(0)
     });
   }
 


### PR DESCRIPTION
We ran into a bug where a `% of parent` metric would crash with a 500 if the parents value is actually 0. 

The error returned by druid is:

```
error: Unknown exception: Instantiation of [simple type, class io.druid.query.topn.TopNQuery] value failed: Missing fields [[null]] for postAggregator [dimension__percent_of_parent]
```

Caused by this post aggregate:

```
  "postAggregations": [
    {
      "type": "expression",
      "expression": "(cast(\"!T_0\",'DOUBLE')/1000000)",
      "name": "__formula_dimension__percent_of_parent"
    },
    {
      "type": "expression",
      "expression": "null",
      "name": "dimension__percent_of_parent"
    }
  ],
```

Falling back to 0 in this case seemed pretty sensible, tell me if you have another preference.

