### PR TITLE
Make segment column resizeable

### DIFF
--- a/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
+++ b/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
@@ -121,7 +121,7 @@ export class DimensionMeasurePanel extends React.Component<DimensionMeasurePanel
           direction={Direction.TOP}
           min={minDividerPosition}
           max={maxDividerPosition}
-          initialValue={dividerPosition} />}
+          value={dividerPosition} />}
         <MeasuresTile
           menuStage={menuStage}
           style={measureListStyle}

--- a/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
+++ b/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
@@ -26,7 +26,7 @@ import { Unary } from "../../../common/utils/functional/functional";
 import { clamp } from "../../utils/dom/dom";
 import { DimensionListTile } from "../dimension-list-tile/dimension-list-tile";
 import { MeasuresTile } from "../measures-tile/measures-tile";
-import { Direction, ResizeHandle } from "../resize-handle/resize-handle";
+import { Direction, DragHandle, ResizeHandle } from "../resize-handle/resize-handle";
 import "./dimension-measure-panel.scss";
 
 export const MIN_PANEL_SIZE = 100;
@@ -116,13 +116,15 @@ export class DimensionMeasurePanel extends React.Component<DimensionMeasurePanel
           triggerFilterMenu={triggerFilterMenu}
           style={dimensionListStyle}
         />
-        {showResizeHandle && <ResizeHandle
-          renderIcon={true}
-          onResize={this.saveDividerPosition}
-          direction={Direction.TOP}
-          min={minDividerPosition}
-          max={maxDividerPosition}
-          value={dividerPosition} />}
+        {showResizeHandle &&
+            <ResizeHandle
+              onResize={this.saveDividerPosition}
+              direction={Direction.TOP}
+              min={minDividerPosition}
+              max={maxDividerPosition}
+              value={dividerPosition}>
+              <DragHandle />
+            </ResizeHandle>}
         <MeasuresTile
           menuStage={menuStage}
           style={measureListStyle}

--- a/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
+++ b/src/client/components/dimension-measure-panel/dimension-measure-panel.tsx
@@ -117,6 +117,7 @@ export class DimensionMeasurePanel extends React.Component<DimensionMeasurePanel
           style={dimensionListStyle}
         />
         {showResizeHandle && <ResizeHandle
+          renderIcon={true}
           onResize={this.saveDividerPosition}
           direction={Direction.TOP}
           min={minDividerPosition}

--- a/src/client/components/resize-handle/resize-handle.mocha.tsx
+++ b/src/client/components/resize-handle/resize-handle.mocha.tsx
@@ -30,7 +30,7 @@ describe("ResizeHandle", () => {
         direction={Direction.LEFT}
         min={240}
         max={400}
-        initialValue={100}
+        value={300}
       />
     );
 

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -30,13 +30,14 @@ export interface ResizeHandleProps {
   value: number;
   onResize?: (newX: number) => void;
   onResizeEnd?: () => void;
-  renderIcon?: boolean;
 }
 
 export interface ResizeHandleState {
   dragging?: boolean;
   anchor?: number;
 }
+
+export const DragHandle = () => <SvgIcon svg={require("../../icons/drag-handle.svg")} />;
 
 export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandleState> {
 
@@ -99,7 +100,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
   }
 
   render() {
-    const { direction, children, value, renderIcon } = this.props;
+    const { direction, children, value } = this.props;
 
     const style: React.CSSProperties = {
       [direction]: value
@@ -110,7 +111,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
       style={style}
       onMouseDown={this.onMouseDown}
     >
-      {renderIcon && <SvgIcon svg={require("../../icons/drag-handle.svg")} />}
+      {children}
     </div>;
   }
 }

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -44,6 +44,8 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
   state: ResizeHandleState = {};
 
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+
     window.addEventListener("mouseup", this.onGlobalMouseUp);
     window.addEventListener("mousemove", this.onGlobalMouseMove);
 

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -34,7 +34,6 @@ export interface ResizeHandleProps {
 
 export interface ResizeHandleState {
   dragging?: boolean;
-  startValue?: number;
   currentValue?: number;
   anchor?: number;
 }
@@ -54,7 +53,6 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
 
     this.setState({
       dragging: true,
-      startValue: newX,
       currentValue: newX,
       anchor: eventX - newX
     });

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -76,7 +76,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
 
   onGlobalMouseMove = (event: MouseEvent) => {
     const { anchor } = this.state;
-    const currentValue = this.constrainValue(this.getCoordinate(event)) - anchor;
+    const currentValue = this.constrainValue(this.getCoordinate(event) - anchor);
     this.setState({ currentValue });
     if (!!this.props.onResize) this.props.onResize(currentValue);
   }

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -30,6 +30,7 @@ export interface ResizeHandleProps {
   value: number;
   onResize?: (newX: number) => void;
   onResizeEnd?: () => void;
+  renderIcon?: boolean;
 }
 
 export interface ResizeHandleState {
@@ -98,7 +99,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
   }
 
   render() {
-    const { direction, children, value } = this.props;
+    const { direction, children, value, renderIcon } = this.props;
 
     const style: React.CSSProperties = {
       [direction]: value
@@ -109,7 +110,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
       style={style}
       onMouseDown={this.onMouseDown}
     >
-      {children === undefined ? <SvgIcon svg={require("../../icons/drag-handle.svg")} /> : children}
+      {renderIcon && <SvgIcon svg={require("../../icons/drag-handle.svg")} />}
     </div>;
   }
 }

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -107,7 +107,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
   }
 
   render() {
-    const { direction } = this.props;
+    const { direction, children } = this.props;
 
     const style: React.CSSProperties = {
       [direction]: this.state.currentValue
@@ -118,7 +118,7 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
       style={style}
       onMouseDown={this.onMouseDown}
     >
-      <SvgIcon svg={require("../../icons/drag-handle.svg")} />
+      {children === undefined ? <SvgIcon svg={require("../../icons/drag-handle.svg")} /> : children}
     </div>;
   }
 }

--- a/src/client/components/resize-handle/resize-handle.tsx
+++ b/src/client/components/resize-handle/resize-handle.tsx
@@ -27,14 +27,13 @@ export interface ResizeHandleProps {
   direction: Direction;
   min: number;
   max: number;
-  initialValue: number;
+  value: number;
   onResize?: (newX: number) => void;
-  onResizeEnd?: (newX: number) => void;
+  onResizeEnd?: () => void;
 }
 
 export interface ResizeHandleState {
   dragging?: boolean;
-  currentValue?: number;
   anchor?: number;
 }
 
@@ -48,13 +47,12 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
     window.addEventListener("mouseup", this.onGlobalMouseUp);
     window.addEventListener("mousemove", this.onGlobalMouseMove);
 
-    const newX = this.state.currentValue;
+    const { value } = this.props;
     const eventX = this.getValue(event);
 
     this.setState({
       dragging: true,
-      currentValue: newX,
-      anchor: eventX - newX
+      anchor: eventX - value
     });
 
     event.preventDefault();
@@ -68,21 +66,14 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
     window.removeEventListener("mousemove", this.onGlobalMouseMove);
 
     if (isFunction(this.props.onResizeEnd)) {
-      this.props.onResizeEnd(this.state.currentValue);
+      this.props.onResizeEnd();
     }
   }
 
   onGlobalMouseMove = (event: MouseEvent) => {
     const { anchor } = this.state;
     const currentValue = this.constrainValue(this.getCoordinate(event) - anchor);
-    this.setState({ currentValue });
     if (!!this.props.onResize) this.props.onResize(currentValue);
-  }
-
-  componentDidMount() {
-    this.setState({
-      currentValue: this.constrainValue(this.props.initialValue)
-    });
   }
 
   private getValue(event: MouseEvent | React.MouseEvent<HTMLElement>): number {
@@ -107,10 +98,10 @@ export class ResizeHandle extends React.Component<ResizeHandleProps, ResizeHandl
   }
 
   render() {
-    const { direction, children } = this.props;
+    const { direction, children, value } = this.props;
 
     const style: React.CSSProperties = {
-      [direction]: this.state.currentValue
+      [direction]: value
     };
 
     return <div

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -586,6 +586,7 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
           newSeriesExpression={this.newExpressionSeries}
         />}
         {!this.isSmallDevice() && !layout.factPanel.hidden && <ResizeHandle
+          renderIcon={true}
           direction={Direction.LEFT}
           value={layout.factPanel.width}
           onResize={this.onFactPanelResize}
@@ -645,6 +646,7 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
         </div>
 
         {!this.isSmallDevice() && !layout.pinboard.hidden && <ResizeHandle
+          renderIcon={true}
           direction={Direction.RIGHT}
           value={layout.pinboard.width}
           onResize={this.onPinboardPanelResize}

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -48,7 +48,7 @@ import { FilterTile } from "../../components/filter-tile/filter-tile";
 import { GlobalEventListener } from "../../components/global-event-listener/global-event-listener";
 import { ManualFallback } from "../../components/manual-fallback/manual-fallback";
 import { PinboardPanel } from "../../components/pinboard-panel/pinboard-panel";
-import { Direction, ResizeHandle } from "../../components/resize-handle/resize-handle";
+import { Direction, DragHandle, ResizeHandle } from "../../components/resize-handle/resize-handle";
 import { SeriesTilesRow } from "../../components/series-tile/series-tiles-row";
 import { SplitTile } from "../../components/split-tile/split-tile";
 import { SvgIcon } from "../../components/svg-icon/svg-icon";
@@ -586,14 +586,15 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
           newSeriesExpression={this.newExpressionSeries}
         />}
         {!this.isSmallDevice() && !layout.factPanel.hidden && <ResizeHandle
-          renderIcon={true}
           direction={Direction.LEFT}
           value={layout.factPanel.width}
           onResize={this.onFactPanelResize}
           onResizeEnd={this.onPanelResizeEnd}
           min={MIN_PANEL_WIDTH}
           max={MAX_PANEL_WIDTH}
-        />}
+        >
+          <DragHandle />
+        </ResizeHandle>}
 
         <div className="center-panel" style={styles.centerPanel}>
           <div className="center-top-bar">
@@ -646,14 +647,15 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
         </div>
 
         {!this.isSmallDevice() && !layout.pinboard.hidden && <ResizeHandle
-          renderIcon={true}
           direction={Direction.RIGHT}
           value={layout.pinboard.width}
           onResize={this.onPinboardPanelResize}
           onResizeEnd={this.onPanelResizeEnd}
           min={MIN_PANEL_WIDTH}
           max={MAX_PANEL_WIDTH}
-        />}
+        >
+          <DragHandle />
+         </ResizeHandle>}
         {!layout.pinboard.hidden && <PinboardPanel
           style={styles.pinboardPanel}
           clicker={clicker}

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -587,7 +587,7 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
         />}
         {!this.isSmallDevice() && !layout.factPanel.hidden && <ResizeHandle
           direction={Direction.LEFT}
-          initialValue={layout.factPanel.width}
+          value={layout.factPanel.width}
           onResize={this.onFactPanelResize}
           onResizeEnd={this.onPanelResizeEnd}
           min={MIN_PANEL_WIDTH}
@@ -646,7 +646,7 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
 
         {!this.isSmallDevice() && !layout.pinboard.hidden && <ResizeHandle
           direction={Direction.RIGHT}
-          initialValue={layout.pinboard.width}
+          value={layout.pinboard.width}
           onResize={this.onPinboardPanelResize}
           onResizeEnd={this.onPanelResizeEnd}
           min={MIN_PANEL_WIDTH}

--- a/src/client/visualizations/table/table.scss
+++ b/src/client/visualizations/table/table.scss
@@ -18,7 +18,6 @@
 @import '../../imports';
 
 $header-height: 38px;
-$segment-width: 300px;
 $measure-width: 130px;
 $row-height: 30px;
 $space-left: 10px;
@@ -91,7 +90,7 @@ $header-padding-top: 12px;
       background-color: $white;
       left: 0;
       top: 0;
-      width: $segment-width - $space-left;
+      width: calc(100% - #{$space-left});
       height: $header-height;
       overflow: hidden;
       padding: $header-padding-top 0 0 6px;
@@ -105,6 +104,11 @@ $header-padding-top: 12px;
 
       .sort-arrow {
         @include sort-arrow;
+      }
+
+      .resize-handle {
+        top: 0;
+        background-color: $background-lightest;
       }
     }
 

--- a/src/client/visualizations/table/table.scss
+++ b/src/client/visualizations/table/table.scss
@@ -82,6 +82,7 @@ $header-padding-top: 12px;
       background-color: $white;
       border-top-left-radius: $corner;
       border-bottom-left-radius: $corner;
+      border-right: 1px solid $border-super-light;
     }
 
 
@@ -108,7 +109,7 @@ $header-padding-top: 12px;
 
       .resize-handle {
         top: 0;
-        background-color: $background-lightest;
+        margin-left: 0;
       }
     }
 

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -51,7 +51,7 @@ const ROW_HEIGHT = 30;
 const SPACE_LEFT = 10;
 const SPACE_RIGHT = 10;
 const HIGHLIGHT_BUBBLE_V_OFFSET = -4;
-const MAX_SEGMENT_WIDTH = Number.MAX_SAFE_INTEGER;
+const MIN_DIMENSION_WIDTH = 100;
 
 function getFilterFromDatum(splits: Splits, flatDatum: PseudoDatum): Filter {
   const splitNesting = flatDatum["__nest"];
@@ -100,6 +100,7 @@ export interface TableState extends BaseVisualizationState {
 
 export class Table extends BaseVisualization<TableState> {
   protected className = TABLE_MANIFEST.name;
+  protected innerTableRef?: HTMLDivElement;
 
   getDefaultState(): TableState {
     return { flatData: null, hoverRow: null, segmentWidth: this.defaultSegmentWidth(), ...super.getDefaultState() };
@@ -109,6 +110,14 @@ export class Table extends BaseVisualization<TableState> {
     const { isThumbnail } = this.props;
 
     return isThumbnail ? THUMBNAIL_SEGMENT_WIDTH : SEGMENT_WIDTH;
+  }
+
+  maxSegmentWidth(): number {
+    if (this.innerTableRef) {
+      return this.innerTableRef.clientWidth - MIN_DIMENSION_WIDTH;
+    }
+
+    return this.defaultSegmentWidth();
   }
 
   getSegmentWidth(): number {
@@ -371,6 +380,10 @@ export class Table extends BaseVisualization<TableState> {
     this.setState({ segmentWidth });
   }
 
+  setInnerTableRef = (element: HTMLDivElement) => {
+    this.innerTableRef = element;
+  }
+
   protected renderInternals() {
     const { clicker, essence, stage } = this.props;
     const { flatData, scrollTop, hoverRow, segmentWidth } = this.state;
@@ -482,12 +495,12 @@ export class Table extends BaseVisualization<TableState> {
       left: this.getSegmentWidth()
     };
 
-    return <div className="internals table-inner">
+    return <div className="internals table-inner" ref={this.setInnerTableRef}>
       <ResizeHandle
         direction={Direction.LEFT}
         onResize={this.setSegmentWidth}
         min={this.defaultSegmentWidth()}
-        max={MAX_SEGMENT_WIDTH}
+        max={this.maxSegmentWidth()}
         value={segmentWidth}
       />
       <Scroller

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -466,13 +466,6 @@ export class Table extends BaseVisualization<TableState> {
 
     const corner = <div className="corner">
       <div className="corner-wrap">{segmentTitle}</div>
-      <ResizeHandle
-        direction={Direction.LEFT}
-        onResize={this.setSegmentWidth}
-        min={this.defaultSegmentWidth()}
-        max={MAX_SEGMENT_WIDTH}
-        value={segmentWidth}
-      />
     </div>;
 
     const measuresCount = essence.getConcreteSeries().size;
@@ -490,6 +483,13 @@ export class Table extends BaseVisualization<TableState> {
     };
 
     return <div className="internals table-inner">
+      <ResizeHandle
+        direction={Direction.LEFT}
+        onResize={this.setSegmentWidth}
+        min={this.defaultSegmentWidth()}
+        max={MAX_SEGMENT_WIDTH}
+        value={segmentWidth}
+      />
       <Scroller
         ref="scroller"
         layout={scrollerLayout}

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -373,7 +373,7 @@ export class Table extends BaseVisualization<TableState> {
 
   protected renderInternals() {
     const { clicker, essence, stage } = this.props;
-    const { flatData, scrollTop, hoverRow } = this.state;
+    const { flatData, scrollTop, hoverRow, segmentWidth } = this.state;
     const { splits, dataCube } = essence;
 
     const segmentTitle = splits.splits.map(split => essence.dataCube.getDimension(split.reference).title).join(", ");
@@ -472,7 +472,7 @@ export class Table extends BaseVisualization<TableState> {
         onResize={this.setSegmentWidth}
         min={defaultSegmentWidth}
         max={MAX_SEGMENT_WIDTH}
-        initialValue={defaultSegmentWidth}
+        initialValue={segmentWidth || defaultSegmentWidth}
         children={null}
       />
     </div>;

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -51,7 +51,7 @@ const ROW_HEIGHT = 30;
 const SPACE_LEFT = 10;
 const SPACE_RIGHT = 10;
 const HIGHLIGHT_BUBBLE_V_OFFSET = -4;
-const MAX_SEGMENT_WIDTH = 1000;
+const MAX_SEGMENT_WIDTH = Number.MAX_SAFE_INTEGER;
 
 function getFilterFromDatum(splits: Splits, flatDatum: PseudoDatum): Filter {
   const splitNesting = flatDatum["__nest"];

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -95,14 +95,14 @@ export interface PositionHover {
 export interface TableState extends BaseVisualizationState {
   flatData?: PseudoDatum[];
   hoverRow?: Datum;
-  segmentWidth?: number;
+  segmentWidth: number;
 }
 
 export class Table extends BaseVisualization<TableState> {
   protected className = TABLE_MANIFEST.name;
 
   getDefaultState(): TableState {
-    return { flatData: null, hoverRow: null, ...super.getDefaultState() };
+    return { flatData: null, hoverRow: null, segmentWidth: this.defaultSegmentWidth(), ...super.getDefaultState() };
   }
 
   defaultSegmentWidth(): number {
@@ -464,15 +464,14 @@ export class Table extends BaseVisualization<TableState> {
       <div className="highlight">{highlighter}</div>
     </div>;
 
-    const defaultSegmentWidth = this.defaultSegmentWidth();
     const corner = <div className="corner">
       <div className="corner-wrap">{segmentTitle}</div>
       <ResizeHandle
         direction={Direction.LEFT}
         onResize={this.setSegmentWidth}
-        min={defaultSegmentWidth}
+        min={this.defaultSegmentWidth()}
         max={MAX_SEGMENT_WIDTH}
-        initialValue={segmentWidth || defaultSegmentWidth}
+        value={segmentWidth}
         children={null}
       />
     </div>;

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -472,7 +472,6 @@ export class Table extends BaseVisualization<TableState> {
         min={this.defaultSegmentWidth()}
         max={MAX_SEGMENT_WIDTH}
         value={segmentWidth}
-        children={null}
       />
     </div>;
 

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -473,6 +473,7 @@ export class Table extends BaseVisualization<TableState> {
         min={defaultSegmentWidth}
         max={MAX_SEGMENT_WIDTH}
         initialValue={defaultSegmentWidth}
+        children={null}
       />
     </div>;
 

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -35,6 +35,7 @@ import { flatMap } from "../../../common/utils/functional/functional";
 import { integerDivision } from "../../../common/utils/general/general";
 import { Delta } from "../../components/delta/delta";
 import { HighlightModal } from "../../components/highlight-modal/highlight-modal";
+import { Direction, ResizeHandle } from "../../components/resize-handle/resize-handle";
 import { Scroller, ScrollerLayout } from "../../components/scroller/scroller";
 import { SvgIcon } from "../../components/svg-icon/svg-icon";
 import { classNames } from "../../utils/dom/dom";
@@ -50,6 +51,7 @@ const ROW_HEIGHT = 30;
 const SPACE_LEFT = 10;
 const SPACE_RIGHT = 10;
 const HIGHLIGHT_BUBBLE_V_OFFSET = -4;
+const MAX_SEGMENT_WIDTH = 1000;
 
 function getFilterFromDatum(splits: Splits, flatDatum: PseudoDatum): Filter {
   const splitNesting = flatDatum["__nest"];
@@ -93,6 +95,7 @@ export interface PositionHover {
 export interface TableState extends BaseVisualizationState {
   flatData?: PseudoDatum[];
   hoverRow?: Datum;
+  segmentWidth?: number;
 }
 
 export class Table extends BaseVisualization<TableState> {
@@ -102,10 +105,15 @@ export class Table extends BaseVisualization<TableState> {
     return { flatData: null, hoverRow: null, ...super.getDefaultState() };
   }
 
-  getSegmentWidth(): number {
+  defaultSegmentWidth(): number {
     const { isThumbnail } = this.props;
 
     return isThumbnail ? THUMBNAIL_SEGMENT_WIDTH : SEGMENT_WIDTH;
+  }
+
+  getSegmentWidth(): number {
+    const { segmentWidth } = this.state;
+    return segmentWidth || this.defaultSegmentWidth();
   }
 
   calculateMousePosition(x: number, y: number): PositionHover {
@@ -359,6 +367,10 @@ export class Table extends BaseVisualization<TableState> {
     ];
   }
 
+  setSegmentWidth = (segmentWidth: number) => {
+    this.setState({ segmentWidth });
+  }
+
   protected renderInternals() {
     const { clicker, essence, stage } = this.props;
     const { flatData, scrollTop, hoverRow } = this.state;
@@ -452,8 +464,16 @@ export class Table extends BaseVisualization<TableState> {
       <div className="highlight">{highlighter}</div>
     </div>;
 
+    const defaultSegmentWidth = this.defaultSegmentWidth();
     const corner = <div className="corner">
       <div className="corner-wrap">{segmentTitle}</div>
+      <ResizeHandle
+        direction={Direction.LEFT}
+        onResize={this.setSegmentWidth}
+        min={defaultSegmentWidth}
+        max={MAX_SEGMENT_WIDTH}
+        initialValue={defaultSegmentWidth}
+      />
     </div>;
 
     const measuresCount = essence.getConcreteSeries().size;


### PR DESCRIPTION
Fixes #183 

That was pretty straight forward! Maybe too easy, pretty sure I missed something 😛 

The original ticket wanted a "strong visual separation between dimensions and measures cells" probably makes more sense than the weird grey bar I added 😸 but I haven't done it yet. This probably just means a bar dividing the segment column and the others?

I like to change the `ResizeHandle` and make the `value` a controlled property instead. The state is currently kept in the component rendering the `ResizeHandle` as well as the `ResizeHandle` itself, which can easily lead to bugs like the one I describe in ef05a96 (in this case due to handle being rerendered but the component rendering it is not). WDYT?

![resize-column](https://user-images.githubusercontent.com/651816/60678443-c638e580-9e84-11e9-91d0-48bb2fc9985d.gif)
