### PR TITLE
print-config: wait for stdout flush before exiting

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -297,13 +297,13 @@ if (PRINT_CONFIG) {
   SETTINGS_MANAGER.getSettings({
     timeout: 10000
   }).then(appSettings => {
-    console.log(appSettingsToYAML(appSettings, withComments, {
+    const config = appSettingsToYAML(appSettings, withComments, {
       header: true,
       version: VERSION,
       verbose: VERBOSE,
       port: SERVER_SETTINGS.getPort()
-    }));
-    process.exit();
+    });
+    process.stdout.write(config, () => process.exit());
   }).catch((e: Error) => {
     exitWithError("There was an error generating a config: " + e.message);
   });


### PR DESCRIPTION
Turnilo print-config command truncate configuration to 64KiB. We should exit application after stdout flush.

Fixes #145 