### PR TITLE
Show tooltip on BarChart

### DIFF
--- a/src/client/visualizations/bar-chart/bar-chart.tsx
+++ b/src/client/visualizations/bar-chart/bar-chart.tsx
@@ -456,7 +456,7 @@ export class BarChart extends BaseVisualization<BarChartState> {
 
     if (this.hasAnySelectionGoingOn()) return false;
     if (!hoverInfo) return false;
-    if (hoverInfo.series !== series) return false;
+    if (!hoverInfo.series.equals(series)) return false;
 
     const filter = (path: Datum[]) => getFilterFromDatum(splits, path);
 


### PR DESCRIPTION
ConcreteSeries are objects created on demand so it is impossible to compare them by reference - use equals instead. Then HoverBubble can find it's own series and display properly.

Fixes #461 