### PR TITLE
Fixing visible scrollbar when filter name is long

### DIFF
--- a/src/client/utils/styles/_tiles-item.scss
+++ b/src/client/utils/styles/_tiles-item.scss
@@ -49,6 +49,7 @@
     margin-right: 20px;
     height: 16px;
     margin-top: 7px;
+    overflow-y: hidden;
   }
 
   .remove {


### PR DESCRIPTION
Adding `overflow-y: hidden` to prevent showing scrollbar in filter area