### PR TITLE
Fixing contextmenu to handle items inside it

### DIFF
--- a/src/client/components/bubble-menu/bubble-menu.scss
+++ b/src/client/components/bubble-menu/bubble-menu.scss
@@ -20,6 +20,7 @@
 .bubble-menu {
   @extend %menu-cont;
   padding: $padding-compact;
+  overflow-y: auto;
 
   &.mini {
     padding: $padding-mini;


### PR DESCRIPTION
According to #492 I have just added `overflow-y: auto` to `bubble-menu` to be sure that contextmenu will handle all items inside of it and include the dynamically adjusted height of box while reduce the height of viewport