### PR TITLE
Automatic removal of disabled datasource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "turnilo",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turnilo",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "A web-based exploratory visualization UI for Druid.io",
   "keywords": [
     "imply",


### PR DESCRIPTION
Currently, when datasources gets disabled, Turnilo will still query it and keep it visible in the UI.
As a workaround, one can restart Turnilo service, which eventually ends up refreshing the datasource list.

The changes offered below, remove datasources when they get disabled, by:
1. Removes the datasource when `scanSourceList` gets triggered (only if the datasource is not in the list but exists in the Turnilo's managed datasources).
2. it calls `introspectSources` only on sources that are enabled (same as `scanSourceList`). This means an additional REST call for `sourceList`, however, it reduces 3 calls (every `sourceReintrospectInterval` ms) for druid for querying the datasources state (one `segmentMetadata` and 2 `timeBoundary` queries).