### PR TITLE
Fix Url Shortener example in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -725,11 +725,9 @@ Function will receive two arguments, `request` - [node request module](https://g
 For example:
 
 ```yaml
-
 customization:
   urlShortener: |
-    return fetch('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url))
-      .then(function(response){ return response.text();})
+    return request.get('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url))
 ```
 
 ### External links


### PR DESCRIPTION
`fetch` is not defined in this context and throws a ReferenceError.