### PR TITLE
Fix creating fixed time short URL

### DIFF
--- a/src/client/components/share-menu/share-menu.tsx
+++ b/src/client/components/share-menu/share-menu.tsx
@@ -95,7 +95,7 @@ function linkItems({ essence, customization, timekeeper, onClose, getCubeViewHas
       </li>
       {isRelative && <li
         key="short-url-specific"
-        onClick={() => openShortenerModal(hash, STRINGS.copyFixedTimeUrl)}>
+        onClick={() => openShortenerModal(specificHash, STRINGS.copyFixedTimeUrl)}>
         {STRINGS.createShortFixedUrl}
       </li>}
     </React.Fragment>}


### PR DESCRIPTION
`specificHash` is converted to fixed time, `hash` is not.

https://github.com/allegro/turnilo/blob/1802e4c14d26cc9b9abc93762211fb6db6d07796/src/client/components/share-menu/share-menu.tsx#L70-L71

https://github.com/allegro/turnilo/blob/1802e4c14d26cc9b9abc93762211fb6db6d07796/src/client/components/share-menu/share-menu.tsx#L84-L88