### PR TITLE
Bugfix: incorrect file formatting on consecutive exports.

### DIFF
--- a/src/client/utils/download/download.ts
+++ b/src/client/utils/download/download.ts
@@ -46,10 +46,11 @@ export function download({ dataset, options }: DataSetWithTabOptions, fileFormat
 }
 
 export function datasetToFileString(dataset: Dataset, fileFormat: FileFormat, options?: TabulatorOptions): string {
+  const optionsCopy = options ? { ...options } : {};
   if (fileFormat === "csv") {
-    return dataset.toCSV(options);
+    return dataset.toCSV(optionsCopy);
   } else if (fileFormat === "tsv") {
-    return dataset.toTSV(options);
+    return dataset.toTSV(optionsCopy);
   } else {
     const datasetJS = dataset.toJS() as DatasetJSFull;
     return JSON.stringify(datasetJS.data, null, 2);


### PR DESCRIPTION
This PR address the following issue:

- Open a datacube view.
- Head to Share Menu and export to TSV. Observe how downloaded file uses tabulator for separators (as expected).
- Try exporting to CSV - notice how the file still uses tabulator for separators.
- Reload the page and try export to CSV and then to TSV - both files will be separated with comma.

This is caused by Plywood mutating options passed to toTSV() and toCSV() functions (https://github.com/implydata/plywood/blob/master/src/datatypes/dataset.ts#L1218). Now, Turnilo is passing copies of these options instead.

Extracted from https://github.com/allegro/turnilo/pull/533