### PR TITLE
If limit on second split comes as null - switch to 10.

### DIFF
--- a/src/common/visualization-manifests/line-chart/line-chart.ts
+++ b/src/common/visualization-manifests/line-chart/line-chart.ts
@@ -141,7 +141,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
     }
 
     const colorSplit = splits.getSplit(0).update("limit", limit => {
-      if (limit > COLORS_COUNT) {
+      if (limit === null || limit > COLORS_COUNT) {
         autoChanged = true;
         return COLORS_COUNT;
       }


### PR DESCRIPTION
Fixes #605 