### PR TITLE
Make dropdown menu scrollable

### DIFF
--- a/src/client/components/dropdown/dropdown.scss
+++ b/src/client/components/dropdown/dropdown.scss
@@ -63,6 +63,8 @@
     padding: 8px 0;
     width: 100%;
     line-height: 24px;
+    max-height: 50vh;
+    overflow-y: scroll;
   }
 
   &.down .dropdown-menu {


### PR DESCRIPTION
For us at remerge, the list of measures in the [operand-select-dropdown](https://github.com/allegro/turnilo/blob/6d707eacbf0a3b544b0f031f135732638eb64a21/src/client/components/series-menu/arithmetic-series-menu.tsx#L107-L115) is so long, that is doesn't fit on the screen anymore. 

This PR limits the height of the dropdown and makes it scrollable. 
This seems like the simplest solution to this, what do you think?