### PR TITLE
support floating point values in the viewBox property

### DIFF
--- a/src/client/components/svg-icon/svg-icon.tsx
+++ b/src/client/components/svg-icon/svg-icon.tsx
@@ -40,7 +40,7 @@ export class SvgIcon extends React.Component<SvgIconProps, SvgIconState> {
       svgInsides = svg
         .substr(0, svg.length - 6) // remove trailing "</svg>"
         .replace(/^<svg [^>]+>\s*/i, (svgDec: string) => {
-          var vbMatch = svgDec.match(/viewBox="([\d ]+)"/);
+          var vbMatch = svgDec.match(/viewBox="([\d. ]+)"/);
           if (vbMatch) viewBox = vbMatch[1];
           return "";
         });


### PR DESCRIPTION
I got an SVG icon from our designers and the `viewBox` property had a floating-point value in it, so the property was not assigned. Small fix for that 😸 