### PR TITLE
Pass client IP address to url shortener function

### DIFF
--- a/config-examples.yaml
+++ b/config-examples.yaml
@@ -1,5 +1,6 @@
 customization:
   urlShortener: |
+    // also available: context.clientIp
     return request.get('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url))
 dataCubes:
   - name: wiki

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -737,7 +737,7 @@ customization:
 ### Url Shortener
 
 Turnilo supports url shorteners for generating short links for current view definitions. This is done by defining function body in configuration.
-Function will receive two arguments, `request` - [node request module](https://github.com/request/request-promise-native) and `url` with current hash. Function should return Promise with shortened url as string inside.
+Function will receive three arguments, `request` - [node request module](https://github.com/request/request-promise-native), `url` with current hash, and `context` which includes: `clientIp` (the ip of the original client, considering a possible XFF header). Function should return Promise with shortened url as string inside.
 
 
 

--- a/src/common/models/url-shortener/url-shortener.ts
+++ b/src/common/models/url-shortener/url-shortener.ts
@@ -15,9 +15,13 @@
  */
 
 import { Instance } from "immutable-class";
-import { Binary } from "../../utils/functional/functional";
+import { Ternary } from "../../utils/functional/functional";
 
-export type UrlShortenerFn = Binary<string, any, Promise<string>>;
+export interface UrlShortenerContext {
+  clientIp: string;
+}
+
+export type UrlShortenerFn = Ternary<any, string, UrlShortenerContext, Promise<string>>;
 export type UrlShortenerDef = string;
 
 export class UrlShortener implements Instance<UrlShortenerDef, UrlShortenerDef> {
@@ -29,7 +33,7 @@ export class UrlShortener implements Instance<UrlShortenerDef, UrlShortenerDef> 
   public readonly shortenerFunction: UrlShortenerFn;
 
   constructor(private shortenerDefinition: string) {
-    this.shortenerFunction = new Function("url", "request", shortenerDefinition) as UrlShortenerFn;
+    this.shortenerFunction = new Function("request", "url", "context", shortenerDefinition) as UrlShortenerFn;
   }
 
   public toJS(): UrlShortenerDef {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -37,8 +37,9 @@ let app = express();
 app.disable("x-powered-by");
 
 const isDev = app.get("env") === "development";
+const isTrustedProxy = SERVER_SETTINGS.getTrustProxy() === "always";
 
-if (SERVER_SETTINGS.getTrustProxy() === "always") {
+if (isTrustedProxy) {
   app.set("trust proxy", 1); // trust first proxy
 }
 
@@ -109,7 +110,7 @@ attachRouter(SERVER_SETTINGS.getLivenessEndpoint(), livenessRouter);
 attachRouter("/plywood", plywoodRouter(settingsGetter));
 attachRouter("/plyql", plyqlRouter(settingsGetter));
 attachRouter("/mkurl", mkurlRouter(settingsGetter));
-attachRouter("/shorten", shortenRouter(settingsGetter));
+attachRouter("/shorten", shortenRouter(settingsGetter, isTrustedProxy));
 
 // View routes
 if (SERVER_SETTINGS.getIframe() === "deny") {

--- a/src/server/routes/shorten/shorten.mocha.ts
+++ b/src/server/routes/shorten/shorten.mocha.ts
@@ -44,7 +44,7 @@ describe("url shortener", () => {
   describe("with succesful shortener", () => {
     before(done => {
       app = express();
-      app.use(shortenPath, shortenRouter(settingsGetterFactory(SuccessUrlShortenerJS)));
+      app.use(shortenPath, shortenRouter(settingsGetterFactory(SuccessUrlShortenerJS), true));
       server = app.listen(0, done);
     });
 
@@ -63,7 +63,7 @@ describe("url shortener", () => {
   describe("without failing shortener", () => {
     before(done => {
       app = express();
-      app.use(shortenPath, shortenRouter(settingsGetterFactory(FailUrlShortenerJS)));
+      app.use(shortenPath, shortenRouter(settingsGetterFactory(FailUrlShortenerJS), true));
       app.use(bodyParser.json());
       server = app.listen(0, done);
     });


### PR DESCRIPTION
This considers XFF headers, with either single IPs or lists of IPs, and
falls back on request.connection.remoteAddress.  There may be more
precise ways of getting the ip, using trusted proxy settings.

Motivation described in #656 