### PR TITLE
Use true when setting 'trust proxy' on express

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ Learn more about it on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/H
 
 **trustProxy** ("none" | "always"), default "none"
 
-Should the server trust the `X-Forwarded-*` headers.
+Should the server trust the `X-Forwarded-*` headers.  If "always", Turnilo will use the left-most entry from the header.
 
 **strictTransportSecurity** ("none" | "always"), default "none"
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -40,7 +40,7 @@ const isDev = app.get("env") === "development";
 const isTrustedProxy = SERVER_SETTINGS.getTrustProxy() === "always";
 
 if (isTrustedProxy) {
-  app.set("trust proxy", 1); // trust first proxy
+  app.set("trust proxy", true); // trust X-Forwarded-*, use left-most entry as the client
 }
 
 function getRoutePath(route: string): string {


### PR DESCRIPTION
'trust proxy' was set to "1", which trusted only the right-most entry in
X-Forwarded-* headers.  This changes it to "true" so that the left-most
entry is used by express as the client ip.  So if XFF looks like this:

123.234.1.1, 10.1.1.10, 234.123.0.1

We would now see 123.234.1.1 as `req.ip`, which is probably more common
and expected.  Prior to this change it would have been 234.123.0.1

'trust proxy' guide here: expressjs.com/en/guide/behind-proxies.html
And the relevant call stack is:
  turnilo -> express (lib/request.js) -> proxy-addr -> forwarded

NOTE: in the future, we could expand the trustProxy setting in the
config to take numbers, addresses, subnets, etc. as allowed by express.
This change does not prevent that, and "always" seems to map naturally
to "true".