### PR TITLE
fix: consider user selected timezone while exporting the reports

### DIFF
--- a/src/client/utils/tabular-options/tabular-options.ts
+++ b/src/client/utils/tabular-options/tabular-options.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { Timezone } from "chronoshift";
 import { List } from "immutable";
 import { AttributeInfo, TabulatorOptions, TimeRange } from "plywood";
 import { Essence } from "../../../common/models/essence/essence";
 import { ConcreteSeries, SeriesDerivation } from "../../../common/models/series/concrete-series";
+import { formatISODateTime } from "../../../common/utils/time/time";
 
 interface SeriesWithDerivation {
   series: ConcreteSeries;
@@ -37,7 +38,7 @@ function findSeriesAndDerivation(name: string, concreteSeriesList: List<Concrete
 export default function tabularOptions(essence: Essence): TabulatorOptions {
   return {
     formatter: {
-      TIME_RANGE: (range: TimeRange) => range.start.toISOString()
+      TIME_RANGE: (range: TimeRange, timezone: Timezone) => formatISODateTime(range.start, timezone)
     },
     attributeFilter: ({ name }: AttributeInfo) => {
       return findSeriesAndDerivation(name, essence.getConcreteSeries()) !== null

--- a/src/common/utils/time/time.ts
+++ b/src/common/utils/time/time.ts
@@ -22,6 +22,7 @@ import { Unary } from "../functional/functional";
 
 const ISO_FORMAT_DATE = "YYYY-MM-DD";
 const ISO_FORMAT_TIME = "HH:mm";
+const ISO_FORMAT_DATE_TIME = "YYYY-MM-DDTHH:mm:ss.sssZ";
 const FORMAT_FULL_MONTH_WITH_YEAR = "MMMM YYYY";
 
 export function getMoment(date: Date, timezone: Timezone): Moment {
@@ -164,6 +165,10 @@ export function formatTimeElapsed(date: Date, timezone: Timezone): string {
 
 export function formatDateTime(date: Date, timezone: Timezone): string {
   return getMoment(date, timezone).format(FULL_FORMAT);
+}
+
+export function formatISODateTime(date: Date, timezone: Timezone): string {
+  return getMoment(date, timezone).format(ISO_FORMAT_DATE_TIME);
 }
 
 export function formatISODate(date: Date, timezone: Timezone): string {


### PR DESCRIPTION
problem:
    Time in CSV exported reports are always in UTC timezone irrespective of user
    selected timezone in the UI. There are use case when time in the exported
    reports should be other timezone than UTC.

fix:
    plywood passes the user selected timezone to format function here
    https://github.com/implydata/plywood/blob/master/src/datatypes/dataset.ts#L343
    We can use that to get time in the user selected timezone. The time in reports
    will also have information about timezone because of ISO format.
