### PR TITLE
Fix height of heatmaps main container.

### DIFF
--- a/src/client/visualizations/heat-map/heat-map.tsx
+++ b/src/client/visualizations/heat-map/heat-map.tsx
@@ -61,7 +61,7 @@ class HeatMap extends React.Component<ChartProps> {
 
     const { x, y, color } = this.getScales(dataset.data, TILE_SIZE, series);
 
-    return <div className="heatmap-container" style={{ maxHeight: stage.height }}>
+    return <div className="heatmap-container" style={{ height: stage.height }}>
       <LabelledHeatmap
         stage={stage}
         dataset={dataset.data}


### PR DESCRIPTION
Container should have height of available stage. Because inside container there's a Scroller component, maxHeight is not enough to stretch container.