### PR TITLE
Scatterplot/adjust stage

### DIFF
--- a/src/client/visualizations/scatterplot/scatterplot.tsx
+++ b/src/client/visualizations/scatterplot/scatterplot.tsx
@@ -26,10 +26,15 @@ import {
 
 import "./scatterplot.scss";
 
+import memoizeOne from "memoize-one";
 import { GridLines } from "../../components/grid-lines/grid-lines";
 import { Point } from "./point";
 import { Tooltip } from "./tooltip";
-import { calculateXAxisStage, calculateYAxisStage, getPlottingData } from "./utils/get-plotting-data";
+import {
+  calculateXAxisStage,
+  calculateYAxisStage,
+  preparePlottingData
+} from "./utils/get-plotting-data";
 import { XAxis } from "./x-axis";
 import { YAxis } from "./y-axis";
 
@@ -45,6 +50,8 @@ export class Scatterplot extends React.Component<ChartProps, ScatterplotState> {
     hoveredPoint: null
   };
 
+  getPlottingData = memoizeOne(preparePlottingData);
+
   setPointHover = (datum: Datum): void =>
     this.setState({ hoveredPoint: datum });
 
@@ -55,7 +62,7 @@ export class Scatterplot extends React.Component<ChartProps, ScatterplotState> {
     const { data, essence, stage } = this.props;
     const splitKey = essence.splits.splits.first().toKey();
 
-    const { xTicks, yTicks, xScale, yScale, xSeries, ySeries, plottingStage, scatterplotData } = getPlottingData(data, essence, stage);
+    const { xTicks, yTicks, xScale, yScale, xSeries, ySeries, plottingStage, scatterplotData } = this.getPlottingData(data, essence, stage);
 
     const rightXAxisLabelPosition = stage.width - (plottingStage.width + plottingStage.x);
     const bottomXAxisLabelPosition  = stage.height - (plottingStage.height + plottingStage.y - X_AXIS_LABEL_OFFSET);

--- a/src/client/visualizations/scatterplot/scatterplot.tsx
+++ b/src/client/visualizations/scatterplot/scatterplot.tsx
@@ -34,6 +34,7 @@ import { XAxis } from "./x-axis";
 import { YAxis } from "./y-axis";
 
 const TICK_SIZE = 10;
+const X_AXIS_LABEL_OFFSET = 55;
 
 interface ScatterplotState {
   hoveredPoint: Datum | null;
@@ -57,7 +58,7 @@ export class Scatterplot extends React.Component<ChartProps, ScatterplotState> {
     const { xTicks, yTicks, xScale, yScale, xSeries, ySeries, plottingStage, scatterplotData } = getPlottingData(data, essence, stage);
 
     const rightXAxisLabelPosition = stage.width - (plottingStage.width + plottingStage.x);
-    const bottomXAxisLabelPosition  = stage.height - (plottingStage.height + plottingStage.y - 55); // magic number here
+    const bottomXAxisLabelPosition  = stage.height - (plottingStage.height + plottingStage.y - X_AXIS_LABEL_OFFSET);
     return <div className="scatterplot-container" style={stage.getWidthHeight()}>
       <span className="axis-title" style={{ top: 10, left: 10 }}>{ySeries.title()}</span>
       <span className="axis-title" style={{ bottom: bottomXAxisLabelPosition, right: rightXAxisLabelPosition }}>{xSeries.title()}</span>

--- a/src/client/visualizations/scatterplot/scatterplot.tsx
+++ b/src/client/visualizations/scatterplot/scatterplot.tsx
@@ -56,9 +56,11 @@ export class Scatterplot extends React.Component<ChartProps, ScatterplotState> {
 
     const { xTicks, yTicks, xScale, yScale, xSeries, ySeries, plottingStage, scatterplotData } = getPlottingData(data, essence, stage);
 
+    const rightXAxisLabelPosition = stage.width - (plottingStage.width + plottingStage.x);
+    const bottomXAxisLabelPosition  = stage.height - (plottingStage.height + plottingStage.y - 55); // magic number here
     return <div className="scatterplot-container" style={stage.getWidthHeight()}>
       <span className="axis-title" style={{ top: 10, left: 10 }}>{ySeries.title()}</span>
-      <span className="axis-title" style={{ bottom: 145, right: 10 }}>{xSeries.title()}</span>
+      <span className="axis-title" style={{ bottom: bottomXAxisLabelPosition, right: rightXAxisLabelPosition }}>{xSeries.title()}</span>
       <Tooltip datum={this.state.hoveredPoint} stage={plottingStage} ySeries={ySeries} xSeries={xSeries} yScale={yScale} xScale={xScale} splitKey={splitKey}/>
       <svg viewBox={stage.getViewBox()}>
         <GridLines orientation={"vertical"} stage={plottingStage} ticks={xTicks} scale={xScale} />

--- a/src/client/visualizations/scatterplot/scatterplot.tsx
+++ b/src/client/visualizations/scatterplot/scatterplot.tsx
@@ -57,8 +57,8 @@ export class Scatterplot extends React.Component<ChartProps, ScatterplotState> {
     const { xTicks, yTicks, xScale, yScale, xSeries, ySeries, plottingStage, scatterplotData } = getPlottingData(data, essence, stage);
 
     return <div className="scatterplot-container" style={stage.getWidthHeight()}>
-      <span className="axis-title" style={{ top: 10, left: 10 }}>{xSeries.title()}</span>
-      <span className="axis-title" style={{ bottom: 145, right: 10 }}>{ySeries.title()}</span>
+      <span className="axis-title" style={{ top: 10, left: 10 }}>{ySeries.title()}</span>
+      <span className="axis-title" style={{ bottom: 145, right: 10 }}>{xSeries.title()}</span>
       <Tooltip datum={this.state.hoveredPoint} stage={plottingStage} ySeries={ySeries} xSeries={xSeries} yScale={yScale} xScale={xScale} splitKey={splitKey}/>
       <svg viewBox={stage.getViewBox()}>
         <GridLines orientation={"vertical"} stage={plottingStage} ticks={xTicks} scale={xScale} />

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017-2022 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as d3 from "d3";
+import memoizeOne from "memoize-one";
+import { Dataset, Datum } from "plywood";
+import { Essence } from "../../../../common/models/essence/essence";
+import { ConcreteSeries } from "../../../../common/models/series/concrete-series";
+import { Stage } from "../../../../common/models/stage/stage";
+import { selectFirstSplitDatums } from "../../../utils/dataset/selectors/selectors";
+import { LinearScale, pickTicks } from "../../../utils/linear-scale/linear-scale";
+
+const MARGIN = 40;
+const X_AXIS_HEIGHT = 50;
+const Y_AXIS_WIDTH = 50;
+
+interface PlottingData {
+  xSeries: ConcreteSeries;
+  ySeries: ConcreteSeries;
+  xScale: LinearScale;
+  yScale: LinearScale;
+  xTicks: number[];
+  yTicks: number[];
+  plottingStage: Stage;
+  scatterplotData: Datum[];
+}
+
+function getTicksCount(size: number): number {
+  // so many magic numbers here
+  if (size < 544) {
+    return 4;
+  }
+
+  if (size < 768) {
+    return 6;
+  }
+
+  return 10;
+}
+
+export function preparePlottingData(data: Dataset, essence: Essence, stage: Stage): PlottingData {
+  const [xSeries, ySeries] = essence.getConcreteSeries().toArray();
+  const scatterplotData = selectFirstSplitDatums(data);
+  const xExtent = getExtent(scatterplotData, xSeries);
+  const yExtent = getExtent(scatterplotData, ySeries);
+
+  const plottingStage = calculatePlottingStage(stage);
+  const yScale = d3.scale.linear().domain(yExtent).nice().range([plottingStage.height, 0]);
+  const xScale = d3.scale.linear().domain(xExtent).nice().range([0, plottingStage.width]);
+
+  const xTicks = pickTicks(xScale, getTicksCount(plottingStage.width));
+  const yTicks = pickTicks(yScale, getTicksCount(plottingStage.height));
+
+  return { xSeries, ySeries, xScale, yScale, xTicks, yTicks, plottingStage, scatterplotData };
+}
+
+export const getPlottingData = memoizeOne(preparePlottingData);
+
+export  function getExtent(data: Datum[], series: ConcreteSeries): number[] {
+  const selectValues = (d: Datum) => series.selectValue(d);
+  return d3.extent(data, selectValues);
+}
+
+export function calculatePlottingStageBasedOnWidth(stage: Stage): Stage {
+  return Stage.fromJS({
+    x: Y_AXIS_WIDTH + MARGIN,
+    y: MARGIN,
+    width: stage.width - Y_AXIS_WIDTH - 2 * MARGIN,
+    height: stage.width - X_AXIS_HEIGHT - 2 * MARGIN
+  });
+}
+
+export function calculatePlottingStageBasedOnHeight(stage: Stage): Stage {
+  return Stage.fromJS({
+    x: Y_AXIS_WIDTH + MARGIN,
+    y: MARGIN,
+    width: stage.height - Y_AXIS_WIDTH - 2 * MARGIN,
+    height: stage.height - X_AXIS_HEIGHT - 2 * MARGIN
+  });
+}
+
+export function calculateRegularPlottingStage(stage: Stage): Stage {
+  return Stage.fromJS({
+    x: Y_AXIS_WIDTH + MARGIN,
+    y: MARGIN,
+    width: stage.width - Y_AXIS_WIDTH - 2 * MARGIN,
+    height: stage.height - X_AXIS_HEIGHT - 2 * MARGIN
+  });
+}
+
+export function calculatePlottingStage(stage: Stage): Stage {
+  const ratio = stage.width / stage.height;
+
+  if (ratio <= 1 ) return calculatePlottingStageBasedOnWidth(stage);
+  if (ratio >= 2 ) return calculatePlottingStageBasedOnHeight(stage);
+  return calculateRegularPlottingStage(stage);
+}
+
+export function calculateXAxisStage(stage: Stage): Stage {
+  return Stage.fromJS({
+    x: Y_AXIS_WIDTH + MARGIN,
+    y: stage.height + MARGIN,
+    width: stage.width,
+    height: X_AXIS_HEIGHT
+  });
+}
+
+export function calculateYAxisStage(stage: Stage): Stage {
+  return Stage.fromJS({
+    x: MARGIN,
+    y: MARGIN,
+    width: Y_AXIS_WIDTH,
+    height: stage.height
+  });
+}

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -116,7 +116,7 @@ export function calculatePlottingStage(stage: Stage): Stage {
   const ratio = stage.width / stage.height;
 
   if (ratio <= 1 ) return calculatePlottingStageBasedOnWidth(stage);
-  if (ratio >= 2.5 ) return calculatePlottingStageBasedOnHeight(stage);
+  if (ratio >= 2 ) return calculatePlottingStageBasedOnHeight(stage);
   return calculateRegularPlottingStage(stage);
 }
 

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -27,9 +27,11 @@ const X_AXIS_HEIGHT = 50;
 const Y_AXIS_WIDTH = 50;
 const BREAKPOINT_SMALL = 544;
 const BREAKPOINT_MEDIUM = 768;
+const BREAKPOINT_LARGE = 1248;
 const TICK_COUNT_SMALL = 4;
 const TICK_COUNT_MEDIUM = 6;
-const TICK_COUNT_LARGE = 10;
+const TICK_COUNT_LARGE = 9;
+const TICK_COUNT_DEFAULT = 14;
 
 interface PlottingData {
   xSeries: ConcreteSeries;
@@ -51,7 +53,11 @@ function getTicksCountByDimension(size: number): number {
     return TICK_COUNT_MEDIUM;
   }
 
-  return TICK_COUNT_LARGE;
+  if (size < BREAKPOINT_LARGE) {
+    return TICK_COUNT_LARGE;
+  }
+
+  return TICK_COUNT_DEFAULT;
 }
 
 export function preparePlottingData(data: Dataset, essence: Essence, stage: Stage): PlottingData {
@@ -64,8 +70,10 @@ export function preparePlottingData(data: Dataset, essence: Essence, stage: Stag
   const yScale = d3.scale.linear().domain(yExtent).nice().range([plottingStage.height, 0]);
   const xScale = d3.scale.linear().domain(xExtent).nice().range([0, plottingStage.width]);
 
-  const xTicks = pickTicks(xScale, getTicksCountByDimension(plottingStage.width));
-  const yTicks = pickTicks(yScale, getTicksCountByDimension(plottingStage.height));
+  const xTicksCount = getTicksCountByDimension(plottingStage.width);
+  const yTicksCount =  getTicksCountByDimension(plottingStage.height);
+  const xTicks = pickTicks(xScale, xTicksCount);
+  const yTicks = pickTicks(yScale, yTicksCount);
 
   return { xSeries, ySeries, xScale, yScale, xTicks, yTicks, plottingStage, scatterplotData };
 }
@@ -77,7 +85,7 @@ export  function getExtent(data: Datum[], series: ConcreteSeries): number[] {
   return d3.extent(data, selectValues);
 }
 
-export function calculatePlottingStageBasedOnWidth(stage: Stage): Stage {
+function calculatePlottingStageBasedOnWidth(stage: Stage): Stage {
   return Stage.fromJS({
     x: Y_AXIS_WIDTH + MARGIN,
     y: MARGIN,
@@ -86,7 +94,7 @@ export function calculatePlottingStageBasedOnWidth(stage: Stage): Stage {
   });
 }
 
-export function calculatePlottingStageBasedOnHeight(stage: Stage): Stage {
+function calculatePlottingStageBasedOnHeight(stage: Stage): Stage {
   return Stage.fromJS({
     x: Y_AXIS_WIDTH + MARGIN,
     y: MARGIN,
@@ -95,7 +103,7 @@ export function calculatePlottingStageBasedOnHeight(stage: Stage): Stage {
   });
 }
 
-export function calculateRegularPlottingStage(stage: Stage): Stage {
+function calculateRegularPlottingStage(stage: Stage): Stage {
   return Stage.fromJS({
     x: Y_AXIS_WIDTH + MARGIN,
     y: MARGIN,
@@ -108,7 +116,7 @@ export function calculatePlottingStage(stage: Stage): Stage {
   const ratio = stage.width / stage.height;
 
   if (ratio <= 1 ) return calculatePlottingStageBasedOnWidth(stage);
-  if (ratio >= 2 ) return calculatePlottingStageBasedOnHeight(stage);
+  if (ratio >= 2.5 ) return calculatePlottingStageBasedOnHeight(stage);
   return calculateRegularPlottingStage(stage);
 }
 

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -25,13 +25,9 @@ import { LinearScale, pickTicks } from "../../../utils/linear-scale/linear-scale
 const MARGIN = 40;
 const X_AXIS_HEIGHT = 50;
 const Y_AXIS_WIDTH = 50;
-const BREAKPOINT_SMALL = 544;
-const BREAKPOINT_MEDIUM = 768;
-const BREAKPOINT_LARGE = 1248;
+const BREAKPOINT_SMALL = 768;
 const TICK_COUNT_SMALL = 4;
-const TICK_COUNT_MEDIUM = 6;
-const TICK_COUNT_LARGE = 9;
-const TICK_COUNT_DEFAULT = 14;
+const TICK_COUNT_DEFAULT = 10;
 
 interface PlottingData {
   xSeries: ConcreteSeries;
@@ -47,14 +43,6 @@ interface PlottingData {
 function getTicksCountByDimension(size: number): number {
   if (size < BREAKPOINT_SMALL) {
     return TICK_COUNT_SMALL;
-  }
-
-  if (size < BREAKPOINT_MEDIUM) {
-    return TICK_COUNT_MEDIUM;
-  }
-
-  if (size < BREAKPOINT_LARGE) {
-    return TICK_COUNT_LARGE;
   }
 
   return TICK_COUNT_DEFAULT;

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -25,6 +25,11 @@ import { LinearScale, pickTicks } from "../../../utils/linear-scale/linear-scale
 const MARGIN = 40;
 const X_AXIS_HEIGHT = 50;
 const Y_AXIS_WIDTH = 50;
+const BREAKPOINT_SMALL = 544;
+const BREAKPOINT_MEDIUM = 768;
+const TICK_COUNT_SMALL = 4;
+const TICK_COUNT_MEDIUM = 6;
+const TICK_COUNT_LARGE = 10;
 
 interface PlottingData {
   xSeries: ConcreteSeries;
@@ -37,17 +42,16 @@ interface PlottingData {
   scatterplotData: Datum[];
 }
 
-function getTicksCount(size: number): number {
-  // so many magic numbers here
-  if (size < 544) {
-    return 4;
+function getTicksCountByDimension(size: number): number {
+  if (size < BREAKPOINT_SMALL) {
+    return TICK_COUNT_SMALL;
   }
 
-  if (size < 768) {
-    return 6;
+  if (size < BREAKPOINT_MEDIUM) {
+    return TICK_COUNT_MEDIUM;
   }
 
-  return 10;
+  return TICK_COUNT_LARGE;
 }
 
 export function preparePlottingData(data: Dataset, essence: Essence, stage: Stage): PlottingData {
@@ -60,8 +64,8 @@ export function preparePlottingData(data: Dataset, essence: Essence, stage: Stag
   const yScale = d3.scale.linear().domain(yExtent).nice().range([plottingStage.height, 0]);
   const xScale = d3.scale.linear().domain(xExtent).nice().range([0, plottingStage.width]);
 
-  const xTicks = pickTicks(xScale, getTicksCount(plottingStage.width));
-  const yTicks = pickTicks(yScale, getTicksCount(plottingStage.height));
+  const xTicks = pickTicks(xScale, getTicksCountByDimension(plottingStage.width));
+  const yTicks = pickTicks(yScale, getTicksCountByDimension(plottingStage.height));
 
   return { xSeries, ySeries, xScale, yScale, xTicks, yTicks, plottingStage, scatterplotData };
 }

--- a/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
+++ b/src/client/visualizations/scatterplot/utils/get-plotting-data.ts
@@ -66,8 +66,6 @@ export function preparePlottingData(data: Dataset, essence: Essence, stage: Stag
   return { xSeries, ySeries, xScale, yScale, xTicks, yTicks, plottingStage, scatterplotData };
 }
 
-export const getPlottingData = memoizeOne(preparePlottingData);
-
 export  function getExtent(data: Datum[], series: ConcreteSeries): number[] {
   const selectValues = (d: Datum) => series.selectValue(d);
   return d3.extent(data, selectValues);


### PR DESCRIPTION
Adjust visualization size and ticks based on screen size.
![Zrzut ekranu 2022-02-18 o 09 54 52](https://user-images.githubusercontent.com/22297591/154650256-7c9680a4-fdf3-490b-aec6-b14ebba92af5.png)
![Zrzut ekranu 2022-02-18 o 09 54 40](https://user-images.githubusercontent.com/22297591/154650260-28c4e188-2587-4dd9-9ea2-24f1e7b4e3fc.png)
![Zrzut ekranu 2022-02-18 o 09 54 30](https://user-images.githubusercontent.com/22297591/154650263-a5dd3c07-acf9-437e-a373-89f2e4513220.png)

Move calculations to a separate file