### PR TITLE
Disable adding a Lighthouse PR comment

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,10 +1,9 @@
 name: Lighthouse CI
 
 on:
-  push:
+  pull_request:
     branches:
       - master
-  pull_request: ~
   workflow_dispatch: ~
 
 jobs:
@@ -49,7 +48,6 @@ jobs:
           echo ::set-output name=report_url::$(cat ./.lighthouseci/links.json | jq -r '."http://localhost:9090/"')
 
       - name: Print report URL
-        if: ${{ github.ref != 'refs/heads/master' }}
         uses: actions/github-script@v6
         env:
           REPORT_URL: ${{ steps.report-url.outputs.report_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -49,6 +49,7 @@ jobs:
           echo ::set-output name=report_url::$(cat ./.lighthouseci/links.json | jq -r '."http://localhost:9090/"')
 
       - name: Print report URL
+        if: ${{ github.ref != 'refs/heads/master' }}
         uses: actions/github-script@v6
         env:
           REPORT_URL: ${{ steps.report-url.outputs.report_url }}


### PR DESCRIPTION
After pushing to master

Lighthouse job looks like failing on master in gh actions:
https://github.com/allegro/turnilo/actions/workflows/lighthouse.yml?query=branch%3Amaster
The part that fails is trying to add a PR comment with Lighthouse results, but when pushing to master there is no PR present. 

Proposed solution: 
Print comment when not on master

Alternative solution: Don't run this action on master push