### PR TITLE
Use GH action STEP_SUMMARY to print custom build information

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -13,10 +13,6 @@ jobs:
       IMAGE_NAME: eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/turnilo
       REF_NAME: ${{ github.head_ref }}
 
-    # add permission to comment PR created by dependantbot
-    permissions:
-      issues: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,17 +52,10 @@ jobs:
           echo ::set-output name=app_url::$(gcloud run services describe turnilo-${REF_NAME//[^a-z0-9]/-} --region europe-west1 --format 'value(status.url)')
 
       - name: Print app URL
-        uses: actions/github-script@v6
         env:
           APP_URL: ${{ steps.app-url.outputs.app_url }}
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ':white_check_mark: Deployed successfully to: ' + process.env.APP_URL
-            })
+        run: |
+          echo ":white_check_mark: Deployed successfully to: $APP_URL" >> $GITHUB_STEP_SUMMARY
 
       - name: Delete previous Docker image(s)
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,10 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # add permission to comment PR created by dependantbot
-    permissions:
-      issues: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,17 +48,10 @@ jobs:
           echo ::set-output name=report_url::$(cat ./.lighthouseci/links.json | jq -r '."http://localhost:9090/"')
 
       - name: Print report URL
-        uses: actions/github-script@v6
         env:
           REPORT_URL: ${{ steps.report-url.outputs.report_url }}
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ':stopwatch: Lighthouse report: ' + process.env.REPORT_URL
-            })
+        run: |
+          echo ":stopwatch: Lighthouse report: $REPORT_URL" >> $GITHUB_STEP_SUMMARY
 
       - name: Copy bundle analysis report
         run: cp build/report-*.{html,json} ./.lighthouseci


### PR DESCRIPTION
The deploy link is available here: https://github.com/allegro/turnilo/actions/runs/2311774188, lighthouse report here: https://github.com/allegro/turnilo/actions/runs/2311774187
Not so convenient but it might work for dependant bot's PR