### PR TITLE
viz colors

### DIFF
--- a/docs/configuration-customizations.md
+++ b/docs/configuration-customizations.md
@@ -8,38 +8,12 @@ layout: page
 
 You can define a `customization:` section in the config to configure some aspects of the look and feel of Turnilo.
 
-## Visual
+## Theming Turnilo
 
-Can customize the header background color and logo icon by supplying a color string and SVG string respectively.
+Turnilo allows you to customize colors of user interface. You should keep in sync values in all subsections here. 
+For example brand CSS variable should match main visualization color.
 
-```yaml
-customization:
-    customLogoSvg: >
-      <svg width="300" height="200"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:xlink="http://www.w3.org/1999/xlink">
-        <rect width="100%" height="100%" fill="green" />
-      </svg>
-
-    headerBackground: '#2D95CA'
-```
-
-## Url Shortener
-
-Turnilo supports url shorteners for generating short links for current view definitions. This is done by defining function body in configuration.
-Function will receive three arguments, `request` - [node request module](https://github.com/request/request-promise-native), `url` with current hash, and `context` which includes: `clientIp` (the ip of the original client, considering a possible XFF header). Function should return Promise with shortened url as string inside.
-
-
-
-For example:
-
-```yaml
-customization:
-  urlShortener: |
-    return request.get('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url))
-```
-
-## CSS Variables
+### CSS Variables
 
 Turnilo allows you to override CSS variables to apply your own theming
 
@@ -58,37 +32,71 @@ customization:
     background-base: '#fbfbfb;'
 ```
 
-## Visualisation colors
+### Visualisation colors
 
-Turnilo allows you to define colors for charts.
+Turnilo allows you to override colors for charts to apply your own theming. Default values for each field are defined in [colors.ts](https://github.com/allegro/turnilo/blob/master/src/common/models/colors/colors.ts). 
 
-For example:
+* `main` property is used for drawing marks (lines, bars, points etc.) whenever Turnilo draws single series.
+
+* `series` is an array of colors used for drawing different series marks. For example line chart with two splits will use `series` colors to distinguish different values from second split.
+
+For example, we can override main color and use [Tableu10](https://www.tableau.com/blog/colors-upgrade-tableau-10-56782) color scheme for series:
 
 ```yaml
 customizaiton:
   visualizationColors: 
-    main: #FF5900
+    main: #829aa3
     series:
-      - #2D95CA
-      - #EFB925
-      - #DA4E99
-      - #4CC873
-      - #745CBD
-      - #EA7136
-      - #E68EE0
-      - #218C35
-      - #B0B510
-      - #904064
+      - #4e79a7
+      - #f28e2c
+      - #e15759
+      - #76b7b2
+      - #59a14f
+      - #edc949
+      - #af7aa1
+      - #ff9da7
+      - #9c755f
+      - #bab0ab
 ```
 
-Value is any CSS Color Module Level 3 specifier string. 
-Object is merged with default values, so it is possible to override just one key.
-
-`main` property is used for drawing marks (lines, bars, points etc.) whenever Turnilo draws single series. 
-`series` is an array of colors used for drawing different series marks. 
-For example line chart with two splits will use `series` colors to distinguish different values from second split.
 By default, Turnilo uses 10 different colors for series. But it is possible to define more and Turnilo will adjust necessary split limits.
 
+### Logo
+
+Turnilo allows you to set custom customize logo icon by supplying an SVG string respectively.
+
+```yaml
+customization:
+    customLogoSvg: >
+      <svg width="300" height="200"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="100%" height="100%" fill="green" />
+      </svg>
+```
+
+### Header color
+
+Turnilo allows you to set custom header background color supplying a string with CSS color.
+
+```yaml
+customization:
+  headerBackground: '#2D95CA'
+```
+
+## Url Shortener
+
+Turnilo supports url shorteners for generating short links for current view definitions. This is done by defining function body in configuration.
+Function will receive three arguments, `request` - [node request module](https://github.com/request/request-promise-native), `url` with current hash, and `context` which includes: `clientIp` (the ip of the original client, considering a possible XFF header). Function should return Promise with shortened url as string inside.
+
+
+For example:
+
+```yaml
+customization:
+  urlShortener: |
+    return request.get('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url))
+```
 
 ## External links
 

--- a/docs/configuration-customizations.md
+++ b/docs/configuration-customizations.md
@@ -58,6 +58,38 @@ customization:
     background-base: '#fbfbfb;'
 ```
 
+## Visualisation colors
+
+Turnilo allows you to define colors for charts.
+
+For example:
+
+```yaml
+customizaiton:
+  visualizationColors: 
+    main: #FF5900
+    series:
+      - #2D95CA
+      - #EFB925
+      - #DA4E99
+      - #4CC873
+      - #745CBD
+      - #EA7136
+      - #E68EE0
+      - #218C35
+      - #B0B510
+      - #904064
+```
+
+Value is any CSS Color Module Level 3 specifier string. 
+Object is merged with default values, so it is possible to override just one key.
+
+`main` property is used for drawing marks (lines, bars, points etc.) whenever Turnilo draws single series. 
+`series` is an array of colors used for drawing different series marks. 
+For example line chart with two splits will use `series` colors to distinguish different values from second split.
+By default, Turnilo uses 10 different colors for series. But it is possible to define more and Turnilo will adjust necessary split limits.
+
+
 ## External links
 
 Turnilo supports defining external view links with access to `dataCube`, `filter`, `splits`, and `timezone` objects at link generation time.

--- a/src/client/applications/turnilo-application/turnilo-application.tsx
+++ b/src/client/applications/turnilo-application/turnilo-application.tsx
@@ -36,7 +36,7 @@ import { Ajax } from "../../utils/ajax/ajax";
 import { reportError } from "../../utils/error-reporter/error-reporter";
 import { replaceHash } from "../../utils/url/url";
 import { CubeView } from "../../views/cube-view/cube-view";
-import { SettingsContext, SettingsValue } from "../../views/cube-view/settings-context";
+import { SettingsContext, SettingsContextValue } from "../../views/cube-view/settings-context";
 import { GeneralError } from "../../views/error-view/general-error";
 import { HomeView } from "../../views/home-view/home-view";
 import "./turnilo-application.scss";
@@ -229,21 +229,22 @@ export class TurniloApplication extends React.Component<TurniloApplicationProps,
     }
   }
 
-  private getSettingsContext(): SettingsValue {
+  private getSettingsContext(): SettingsContextValue {
     const { appSettings: { customization } } = this.props;
     return this.constructSettingsContext(customization);
   }
 
+  // NOTE: is memoization needed?
   private constructSettingsContext = memoizeOne((customization: ClientCustomization) => ({ customization }));
 
   render() {
     return <React.StrictMode>
       <main className="turnilo-application">
         <SettingsContext.Provider value={this.getSettingsContext()}>
-        {this.renderView()}
-        {this.renderAboutModal()}
-        <Notifications/>
-        <Questions/>
+          {this.renderView()}
+          {this.renderAboutModal()}
+          <Notifications/>
+          <Questions/>
         </SettingsContext.Provider>
       </main>
     </React.StrictMode>;

--- a/src/client/applications/turnilo-application/turnilo-application.tsx
+++ b/src/client/applications/turnilo-application/turnilo-application.tsx
@@ -38,6 +38,9 @@ import { GeneralError } from "../../views/error-view/general-error";
 import { HomeView } from "../../views/home-view/home-view";
 import "./turnilo-application.scss";
 import { cube, generalError, home, oauthCodeHandler, oauthMessageView, View } from "./view";
+import { SettingsContext, SettingsValue } from "../../views/cube-view/settings-context";
+import memoizeOne from "memoize-one";
+import { ClientCustomization } from "../../../common/models/customization/customization";
 
 export interface TurniloApplicationProps {
   version: string;
@@ -226,13 +229,22 @@ export class TurniloApplication extends React.Component<TurniloApplicationProps,
     }
   }
 
+  private getSettingsContext(): SettingsValue {
+    const { appSettings: { customization } } = this.props;
+    return this.constructSettingsContext(customization);
+  }
+
+  private constructSettingsContext = memoizeOne((customization: ClientCustomization) => ({ customization }));
+
   render() {
     return <React.StrictMode>
       <main className="turnilo-application">
+        <SettingsContext.Provider value={this.getSettingsContext()}>
         {this.renderView()}
         {this.renderAboutModal()}
         <Notifications/>
         <Questions/>
+        </SettingsContext.Provider>
       </main>
     </React.StrictMode>;
   }

--- a/src/client/applications/turnilo-application/turnilo-application.tsx
+++ b/src/client/applications/turnilo-application/turnilo-application.tsx
@@ -16,8 +16,10 @@
  */
 
 import { NamedArray } from "immutable-class";
+import memoizeOne from "memoize-one";
 import React from "react";
 import { ClientAppSettings } from "../../../common/models/app-settings/app-settings";
+import { ClientCustomization } from "../../../common/models/customization/customization";
 import { ClientDataCube } from "../../../common/models/data-cube/data-cube";
 import { Essence } from "../../../common/models/essence/essence";
 import { isEnabled as isOAuthEnabled } from "../../../common/models/oauth/oauth";
@@ -34,13 +36,11 @@ import { Ajax } from "../../utils/ajax/ajax";
 import { reportError } from "../../utils/error-reporter/error-reporter";
 import { replaceHash } from "../../utils/url/url";
 import { CubeView } from "../../views/cube-view/cube-view";
+import { SettingsContext, SettingsValue } from "../../views/cube-view/settings-context";
 import { GeneralError } from "../../views/error-view/general-error";
 import { HomeView } from "../../views/home-view/home-view";
 import "./turnilo-application.scss";
 import { cube, generalError, home, oauthCodeHandler, oauthMessageView, View } from "./view";
-import { SettingsContext, SettingsValue } from "../../views/cube-view/settings-context";
-import memoizeOne from "memoize-one";
-import { ClientCustomization } from "../../../common/models/customization/customization";
 
 export interface TurniloApplicationProps {
   version: string;

--- a/src/client/components/header-bar/header-bar.tsx
+++ b/src/client/components/header-bar/header-bar.tsx
@@ -16,16 +16,16 @@
  */
 
 import React from "react";
-import { ClientCustomization } from "../../../common/models/customization/customization";
+import { useSettingsContext } from "../../views/cube-view/settings-context";
 import "./header-bar.scss";
 
 export interface HeaderBarProps {
-  customization?: ClientCustomization;
   title?: string;
 }
 
 export const HeaderBar: React.FunctionComponent<HeaderBarProps> = props => {
-  const { customization, title } = props;
+  const { title } = props;
+  const { customization } = useSettingsContext();
 
   const headerStyle: React.CSSProperties = customization && customization.headerBackground && { background: customization.headerBackground };
 

--- a/src/client/deserializers/app-settings.ts
+++ b/src/client/deserializers/app-settings.ts
@@ -26,3 +26,29 @@ export function deserialize({ oauth, clientTimeout, customization, version }: Se
     oauth: deserializeOauth(oauth)
   };
 }
+
+/*
+ NOTE: Function is used only for serialize-deserialize cycle in Essence class.
+ Now it's hard to remove that functionality but in the end, Essence does not need to serialize itself.
+*/
+export function serialize(appSettings: ClientAppSettings): SerializedAppSettings {
+  const { clientTimeout, version, customization, oauth } = appSettings;
+  const { visualizationColors, messages, customLogoSvg, hasUrlShortener, locale, headerBackground, sentryDSN, timezones, externalViews } = customization;
+
+  return {
+    clientTimeout,
+    version,
+    oauth,
+    customization: {
+      visualizationColors,
+      messages,
+      customLogoSvg,
+      locale,
+      hasUrlShortener,
+      headerBackground,
+      sentryDSN,
+      timezones: timezones.map(t => t.toJS()),
+      externalViews
+    }
+  };
+}

--- a/src/client/deserializers/customization.ts
+++ b/src/client/deserializers/customization.ts
@@ -19,7 +19,7 @@ import { ClientCustomization, SerializedCustomization } from "../../common/model
 import { deserialize as deserializeLocale } from "../../common/models/locale/locale";
 
 export function deserialize(customization: SerializedCustomization): ClientCustomization {
-  const { headerBackground, messages, locale, customLogoSvg, timezones, externalViews, hasUrlShortener, sentryDSN } = customization;
+  const { headerBackground, messages, locale, customLogoSvg, timezones, externalViews, hasUrlShortener, sentryDSN, visualizationColors } = customization;
   return {
     headerBackground,
     customLogoSvg,
@@ -28,6 +28,7 @@ export function deserialize(customization: SerializedCustomization): ClientCusto
     sentryDSN,
     messages,
     locale: deserializeLocale(locale),
-    timezones: timezones.map(Timezone.fromJS)
+    timezones: timezones.map(Timezone.fromJS),
+    visualizationColors
   };
 }

--- a/src/client/utils/styles/_variables.scss
+++ b/src/client/utils/styles/_variables.scss
@@ -75,8 +75,6 @@ $theme-colors: (
   item-measure-hover: darken($item-measure, 6%),
   item-measure-text: $text-standard,
   item-measure: $item-measure,
-  main-time-area: rgba($brand, 0.14),
-  main-time-line: $brand,
   negative: #e14040,
   pinboard-icon: darken($background-base, 5%),
   positive: #08b157,

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -92,7 +92,7 @@ export interface CubeViewProps {
   hash: string;
   changeCubeAndEssence: Ternary<ClientDataCube, Essence, boolean, void>;
   urlForCubeAndEssence: Binary<ClientDataCube, Essence, string>;
-  getEssenceFromHash: Ternary<string, ClientDataCube, ClientAppSettings, Essence>;
+  getEssenceFromHash: Ternary<string, ClientAppSettings, ClientDataCube, Essence>;
   dataCube: ClientDataCube;
   dataCubes: ClientDataCube[];
   openAboutModal: Fn;
@@ -306,7 +306,7 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
     }
 
     const { getEssenceFromHash, appSettings } = this.props;
-    return getEssenceFromHash(hash, dataCube, appSettings);
+    return getEssenceFromHash(hash, appSettings, dataCube);
   }
 
   globalResizeListener = () => {

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -92,7 +92,7 @@ export interface CubeViewProps {
   hash: string;
   changeCubeAndEssence: Ternary<ClientDataCube, Essence, boolean, void>;
   urlForCubeAndEssence: Binary<ClientDataCube, Essence, string>;
-  getEssenceFromHash: Binary<string, ClientDataCube, Essence>;
+  getEssenceFromHash: Ternary<string, ClientDataCube, ClientAppSettings, Essence>;
   dataCube: ClientDataCube;
   dataCubes: ClientDataCube[];
   openAboutModal: Fn;
@@ -292,7 +292,8 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
   }
 
   getEssenceFromDataCube(dataCube: ClientDataCube): Essence {
-    return Essence.fromDataCube(dataCube);
+    const { appSettings } = this.props;
+    return Essence.fromDataCube(dataCube, appSettings);
   }
 
   getEssenceFromHash(hash: string, dataCube: ClientDataCube): Essence {
@@ -304,8 +305,8 @@ export class CubeView extends React.Component<CubeViewProps, CubeViewState> {
       throw new Error("Hash is required.");
     }
 
-    const { getEssenceFromHash } = this.props;
-    return getEssenceFromHash(hash, dataCube);
+    const { getEssenceFromHash, appSettings } = this.props;
+    return getEssenceFromHash(hash, dataCube, appSettings);
   }
 
   globalResizeListener = () => {

--- a/src/client/views/cube-view/settings-context.ts
+++ b/src/client/views/cube-view/settings-context.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2022 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext } from "react";
+import { ClientCustomization } from "../../../common/models/customization/customization";
+
+export interface SettingsValue {
+  customization: ClientCustomization;
+}
+
+export const SettingsContext = React.createContext<SettingsValue>({
+  get customization(): ClientCustomization {
+    throw new Error("Attempted to consume SettingsContext when there was no Provider in place.");
+  }
+});
+
+export function useSettingsContext(): SettingsValue {
+  return useContext(SettingsContext);
+}

--- a/src/client/views/cube-view/settings-context.ts
+++ b/src/client/views/cube-view/settings-context.ts
@@ -17,16 +17,16 @@
 import React, { useContext } from "react";
 import { ClientCustomization } from "../../../common/models/customization/customization";
 
-export interface SettingsValue {
+export interface SettingsContextValue {
   customization: ClientCustomization;
 }
 
-export const SettingsContext = React.createContext<SettingsValue>({
+export const SettingsContext = React.createContext<SettingsContextValue>({
   get customization(): ClientCustomization {
     throw new Error("Attempted to consume SettingsContext when there was no Provider in place.");
   }
 });
 
-export function useSettingsContext(): SettingsValue {
+export function useSettingsContext(): SettingsContextValue {
   return useContext(SettingsContext);
 }

--- a/src/client/views/home-view/home-view.tsx
+++ b/src/client/views/home-view/home-view.tsx
@@ -73,15 +73,12 @@ export class HomeView extends React.Component<HomeViewProps, HomeViewState> {
   }
 
   render() {
-    const { onOpenAbout, dataCubes, customization } = this.props;
+    const { onOpenAbout, dataCubes } = this.props;
     const { query } = this.state;
     const hasDataCubes = dataCubes.length > 0;
 
     return <div className="home-view">
-      <HeaderBar
-        customization={customization}
-        title={STRINGS.home}
-      >
+      <HeaderBar title={STRINGS.home}>
         <button className="text-button" onClick={onOpenAbout}>
           {STRINGS.infoAndFeedback}
         </button>

--- a/src/client/visualizations/bar-chart/bar-chart.scss
+++ b/src/client/visualizations/bar-chart/bar-chart.scss
@@ -37,6 +37,7 @@
     position: absolute;
 
     .selection-highlight {
+      // TODO: replace with visualisationColors.main
       @include css-variable(border-color, brand);
       pointer-events: none;
       border-width: 1px;
@@ -113,6 +114,7 @@
         }
 
         > rect.background {
+          // TODO: replace with visualisationColors.main
           @include css-variable(fill, brand);
           pointer-events: none;
         }

--- a/src/client/visualizations/bar-chart/bar-chart.scss
+++ b/src/client/visualizations/bar-chart/bar-chart.scss
@@ -114,8 +114,6 @@
         }
 
         > rect.background {
-          // TODO: replace with visualisationColors.main
-          @include css-variable(fill, brand);
           pointer-events: none;
         }
 

--- a/src/client/visualizations/bar-chart/bar-chart.tsx
+++ b/src/client/visualizations/bar-chart/bar-chart.tsx
@@ -54,6 +54,7 @@ import { VisMeasureLabel } from "../../components/vis-measure-label/vis-measure-
 import { SPLIT, VIS_H_PADDING } from "../../config/constants";
 import { classNames, roundToPx } from "../../utils/dom/dom";
 import { ChartPanel, DefaultVisualizationControls, VisualizationProps } from "../../views/cube-view/center-panel/center-panel";
+import { SettingsContext, SettingsContextValue } from "../../views/cube-view/settings-context";
 import { hasHighlightOn } from "../highlight-controller/highlight-controller";
 import "./bar-chart.scss";
 import { BarCoordinates } from "./bar-coordinates";
@@ -168,12 +169,15 @@ export default function BarChartVisualization(props: VisualizationProps) {
 }
 
 class BarChart extends React.Component<ChartProps, BarChartState> {
+  static contextType = SettingsContext;
   protected className = BAR_CHART_MANIFEST.name;
 
   private coordinatesCache: BarCoordinates[][] = [];
   private scroller = React.createRef<Scroller>();
 
   state: BarChartState = this.initState();
+
+  context: SettingsContextValue;
 
   componentDidUpdate() {
     const { scrollerYPosition, scrollerXPosition } = this.state;
@@ -491,6 +495,7 @@ class BarChart extends React.Component<ChartProps, BarChartState> {
   ): { bars: JSX.Element[], highlight: JSX.Element } {
     const { essence } = this.props;
     const { timezone } = essence;
+    const { customization: { visualizationColors } } = this.context;
 
     const bars: JSX.Element[] = [];
     let highlight: JSX.Element;
@@ -547,6 +552,7 @@ class BarChart extends React.Component<ChartProps, BarChartState> {
             className="background"
             width={roundToPx(barWidth)}
             height={roundToPx(Math.abs(height))}
+            fill={visualizationColors.main}
             x={barOffset}
             y={roundToPx(y)}
           />

--- a/src/client/visualizations/bar-chart/improved-bar-chart/bar-chart.tsx
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/bar-chart.tsx
@@ -25,6 +25,7 @@ import { MessageCard } from "../../../components/message-card/message-card";
 import { Scroller } from "../../../components/scroller/scroller";
 import { SPLIT } from "../../../config/constants";
 import { selectMainDatum } from "../../../utils/dataset/selectors/selectors";
+import { useSettingsContext } from "../../../views/cube-view/settings-context";
 import { Highlight } from "../../highlight-controller/highlight";
 import { BarCharts } from "./bar-charts/bar-charts";
 import { InteractionController } from "./interactions/interaction-controller";
@@ -49,8 +50,9 @@ interface BarChartProps {
 }
 
 export const BarChart: React.FunctionComponent<BarChartProps> = props => {
+  const { customization } = useSettingsContext();
   const { dataset, essence, stage, highlight, acceptHighlight, dropHighlight, saveHighlight } = props;
-  const model = create(essence, dataset);
+  const model = create(essence, dataset, customization);
 
   const transposedDataset = transposeDataset(dataset, model);
   if (transposedDataset.length === 0) {

--- a/src/client/visualizations/bar-chart/improved-bar-chart/bar/single-bar.tsx
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/bar/single-bar.tsx
@@ -18,6 +18,7 @@ import { Datum } from "plywood";
 import React from "react";
 import { ConcreteSeries } from "../../../../../common/models/series/concrete-series";
 import { LinearScale } from "../../../../utils/linear-scale/linear-scale";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { BaseBarChartModel } from "../utils/bar-chart-model";
 import { DomainValue } from "../utils/x-domain";
 import { XScale } from "../utils/x-scale";
@@ -32,6 +33,7 @@ interface SingleBarProps {
 }
 
 export const SingleBar: React.FunctionComponent<SingleBarProps> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { datum, xScale, yScale, model: { continuousSplit }, series } = props;
   const [maxHeight] = yScale.range();
   const x = continuousSplit.selectValue<DomainValue>(datum);
@@ -40,11 +42,13 @@ export const SingleBar: React.FunctionComponent<SingleBarProps> = props => {
   const y = series.selectValue(datum);
   const yPos = yScale(y);
   const height = maxHeight - yPos;
+  const fill = visualizationColors.main;
 
   return <rect
     className="bar-chart-bar"
     x={xPos}
     y={yPos}
+    fill={fill}
     width={width}
     height={height} />;
 };

--- a/src/client/visualizations/bar-chart/improved-bar-chart/bar/single-time-shift-bar.tsx
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/bar/single-time-shift-bar.tsx
@@ -16,8 +16,10 @@
 
 import { Datum } from "plywood";
 import React from "react";
+import { alphaMain } from "../../../../../common/models/colors/colors";
 import { ConcreteSeries, SeriesDerivation } from "../../../../../common/models/series/concrete-series";
 import { LinearScale } from "../../../../utils/linear-scale/linear-scale";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { BaseBarChartModel } from "../utils/bar-chart-model";
 import { DomainValue } from "../utils/x-domain";
 import { XScale } from "../utils/x-scale";
@@ -32,6 +34,7 @@ interface SingleTimeShiftBar {
 }
 
 export const SingleTimeShiftBar: React.FunctionComponent<SingleTimeShiftBar> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { datum, xScale, yScale, model: { continuousSplit }, series } = props;
   const [maxHeight] = yScale.range();
   const x = continuousSplit.selectValue<DomainValue>(datum);
@@ -45,17 +48,22 @@ export const SingleTimeShiftBar: React.FunctionComponent<SingleTimeShiftBar> = p
   const yCurrentStart = yScale(yCurrent);
   const yPreviousStart = yScale(yPrevious);
 
+  const currentFill = visualizationColors.main;
+  const previousFill = alphaMain(visualizationColors);
+
   return <React.Fragment>
     <rect
       className="bar-chart-bar-previous"
       x={xStart + rangeBand - SIDE_PADDING - barWidth}
       y={yPreviousStart}
+      fill={previousFill}
       width={barWidth}
       height={maxHeight - yPreviousStart} />
     <rect
       className="bar-chart-bar"
       x={xStart + SIDE_PADDING}
       y={yCurrentStart}
+      fill={currentFill}
       width={barWidth}
       height={maxHeight - yCurrentStart} />
   </React.Fragment>;

--- a/src/client/visualizations/bar-chart/improved-bar-chart/bars/bars.scss
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/bars/bars.scss
@@ -18,6 +18,7 @@
 
 .bar-chart-bars {
   .bar-chart-bar {
+    // TODO: replace with visualisationColors.main
     @include css-variable(fill, brand);
   }
 

--- a/src/client/visualizations/bar-chart/improved-bar-chart/bars/bars.scss
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/bars/bars.scss
@@ -17,16 +17,6 @@
 @import '../../../../imports';
 
 .bar-chart-bars {
-  .bar-chart-bar {
-    // TODO: replace with visualisationColors.main
-    @include css-variable(fill, brand);
-  }
-
-  .bar-chart-bar-previous {
-    @include css-variable(fill, main-time-area);
-  }
-
-
   .bar-chart-total {
     position: absolute;
     top: 15px;

--- a/src/client/visualizations/bar-chart/improved-bar-chart/utils/bar-chart-model.ts
+++ b/src/client/visualizations/bar-chart/improved-bar-chart/utils/bar-chart-model.ts
@@ -17,7 +17,8 @@
 import { Timezone } from "chronoshift";
 import { List, OrderedMap } from "immutable";
 import { Dataset, Datum } from "plywood";
-import { NORMAL_COLORS } from "../../../../../common/models/colors/colors";
+import { VisualizationColors } from "../../../../../common/models/colors/colors";
+import { ClientCustomization } from "../../../../../common/models/customization/customization";
 import { Dimension } from "../../../../../common/models/dimension/dimension";
 import { Essence } from "../../../../../common/models/essence/essence";
 import { ConcreteSeries } from "../../../../../common/models/series/concrete-series";
@@ -70,17 +71,18 @@ function readCommons(essence: Essence): Omit<BarChartModelCommons, "variant"> {
   };
 }
 
-function createColorMap(nominalSplit: Split, dataset: Dataset): ColorMap {
+function createColorMap(nominalSplit: Split, dataset: Dataset, colors: VisualizationColors): ColorMap {
   const datums = selectFirstSplitDatums(dataset);
   return datums.reduce<ColorMap>((map: ColorMap, datum: Datum, i: number) => {
     const key = String(nominalSplit.selectValue(datum));
-    const colorIndex = i % NORMAL_COLORS.length;
-    const color = NORMAL_COLORS[colorIndex];
+    const colorIndex = i % colors.series.length;
+    const color = colors.series[colorIndex];
     return map.set(key, color);
   }, OrderedMap<string, Color>());
 }
 
-export function create(essence: Essence, dataset: Dataset): BarChartModel {
+export function create(essence: Essence, dataset: Dataset, customization: ClientCustomization): BarChartModel {
+  const { visualizationColors } = customization;
   const commons = readCommons(essence);
   if (!hasNominalSplit(essence)) {
     return {
@@ -90,7 +92,7 @@ export function create(essence: Essence, dataset: Dataset): BarChartModel {
   }
   const nominalSplit = getNominalSplit(essence);
   const nominalDimension = getNominalDimension(essence);
-  const colors = createColorMap(nominalSplit, dataset);
+  const colors = createColorMap(nominalSplit, dataset, visualizationColors);
   return {
     ...commons,
     variant: ModelVariantId.STACKED,

--- a/src/client/visualizations/heat-map/utils/scales.ts
+++ b/src/client/visualizations/heat-map/utils/scales.ts
@@ -25,6 +25,7 @@ import { nestedDataset } from "./nested-dataset";
 export type ColorScale = d3.ScaleLinear<string, string>;
 
 const white = "#fff";
+// TODO: replace with visualisationColors.main
 const orange = "#ff5a00";
 
 interface Scales {

--- a/src/client/visualizations/line-chart/base-chart/base-chart.scss
+++ b/src/client/visualizations/line-chart/base-chart/base-chart.scss
@@ -36,7 +36,6 @@
   }
 
   .hover-guide {
-    // TODO: replace with visualisationColors.main
     @include css-variable(stroke, background-brand-light);
     stroke-width: 1;
   }

--- a/src/client/visualizations/line-chart/base-chart/base-chart.scss
+++ b/src/client/visualizations/line-chart/base-chart/base-chart.scss
@@ -36,6 +36,7 @@
   }
 
   .hover-guide {
+    // TODO: replace with visualisationColors.main
     @include css-variable(stroke, background-brand-light);
     stroke-width: 1;
   }

--- a/src/client/visualizations/line-chart/chart-line/chart-line.scss
+++ b/src/client/visualizations/line-chart/chart-line/chart-line.scss
@@ -21,25 +21,16 @@
   pointer-events: none;
 
   .area {
-    @include css-variable(fill, main-time-area);
     stroke: none;
     fill-opacity: .9;
   }
 
   .line {
-    @include css-variable(stroke, main-time-line);
     fill: none;
     stroke-width: 1.6px;
   }
 
   .singleton {
-    @include css-variable(fill, main-time-line);
     stroke: none;
-  }
-
-  .hover {
-    @include css-variable(stroke, main-time-line);
-    fill: $white;
-    stroke-width: 2;
   }
 }

--- a/src/client/visualizations/line-chart/chart-line/chart-line.tsx
+++ b/src/client/visualizations/line-chart/chart-line/chart-line.tsx
@@ -17,8 +17,10 @@
 import * as d3 from "d3";
 import { Datum } from "plywood";
 import React from "react";
+import { alphaMain } from "../../../../common/models/colors/colors";
 import { Stage } from "../../../../common/models/stage/stage";
 import { Unary } from "../../../../common/utils/functional/functional";
+import { useSettingsContext } from "../../../views/cube-view/settings-context";
 import { ContinuousRange, ContinuousScale } from "../utils/continuous-types";
 import "./chart-line.scss";
 import { prepareDataPoints } from "./prepare-data-points";
@@ -37,13 +39,10 @@ export interface ChartLineProps {
   stage: Stage;
 }
 
-const stroke = (color: string, dashed: boolean): Pick<React.CSSProperties, "stroke" | "strokeDasharray"> => ({
-  stroke: color,
-  strokeDasharray: dashed ? "4 2" : undefined
-});
-
 export const ChartLine: React.FunctionComponent<ChartLineProps> = props => {
-  const { color, dashed, getX, getY, dataset, showArea, stage, xScale, yScale } = props;
+  const { customization: { visualizationColors } } = useSettingsContext();
+  const mainColor = visualizationColors.main;
+  const { color = mainColor, dashed, getX, getY, dataset, showArea, stage, xScale, yScale } = props;
 
   const area = d3.area().y0(yScale(0));
   const line = d3.line();
@@ -54,8 +53,15 @@ export const ChartLine: React.FunctionComponent<ChartLineProps> = props => {
   const hasSinglePoint = points.length === 1;
 
   return <g className="chart-line" transform={stage.getTransform()}>
-    {hasMultiplePoints && <path className="line" d={line(scaledPoints)} style={stroke(color, dashed)} />}
-    {hasMultiplePoints && showArea && <path className="area" d={area(scaledPoints)} />}
+    {hasMultiplePoints && <path
+      className="line"
+      d={line(scaledPoints)}
+      stroke={color}
+      strokeDasharray={dashed ? "4 2" : undefined}/>}
+    {hasMultiplePoints && showArea && <path
+      className="area"
+      fill={alphaMain(visualizationColors)}
+      d={area(scaledPoints)}/>}
     {hasSinglePoint && <circle
       className="singleton"
       cx={scaledPoints[0][0]}

--- a/src/client/visualizations/line-chart/charts/charts-per-series/series-chart.tsx
+++ b/src/client/visualizations/line-chart/charts/charts-per-series/series-chart.tsx
@@ -21,6 +21,7 @@ import { ConcreteSeries } from "../../../../../common/models/series/concrete-ser
 import { Stage } from "../../../../../common/models/stage/stage";
 import { VisMeasureLabel } from "../../../../components/vis-measure-label/vis-measure-label";
 import { selectFirstSplitDataset, selectMainDatum, selectSplitDatums } from "../../../../utils/dataset/selectors/selectors";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { BaseChart } from "../../base-chart/base-chart";
 import { ColoredSeriesChartLine } from "../../chart-line/colored-series-chart-line";
 import { SingletonSeriesChartLine } from "../../chart-line/singleton-series-chart-line";
@@ -31,7 +32,6 @@ import { extentAcrossSplits } from "../../utils/extent";
 import { ContinuousTicks } from "../../utils/pick-x-axis-ticks";
 import { getContinuousSplit, getNominalSplit, hasNominalSplit } from "../../utils/splits";
 import { SeriesHoverContent } from "./series-hover-content";
-import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 
 interface SeriesChartProps {
   chartId: string;

--- a/src/client/visualizations/line-chart/charts/charts-per-series/series-chart.tsx
+++ b/src/client/visualizations/line-chart/charts/charts-per-series/series-chart.tsx
@@ -16,7 +16,6 @@
 
 import { Dataset, Datum, NumberRange, TimeRange } from "plywood";
 import React from "react";
-import { NORMAL_COLORS } from "../../../../../common/models/colors/colors";
 import { Essence } from "../../../../../common/models/essence/essence";
 import { ConcreteSeries } from "../../../../../common/models/series/concrete-series";
 import { Stage } from "../../../../../common/models/stage/stage";
@@ -32,6 +31,7 @@ import { extentAcrossSplits } from "../../utils/extent";
 import { ContinuousTicks } from "../../utils/pick-x-axis-ticks";
 import { getContinuousSplit, getNominalSplit, hasNominalSplit } from "../../utils/splits";
 import { SeriesHoverContent } from "./series-hover-content";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 
 interface SeriesChartProps {
   chartId: string;
@@ -46,6 +46,7 @@ interface SeriesChartProps {
 }
 
 export const SeriesChart: React.FunctionComponent<SeriesChartProps> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { chartId, interactions, visualisationStage, chartStage, essence, series, xScale, xTicks, dataset } = props;
   const hasComparison = essence.hasComparison();
   const continuousSplitDataset = selectFirstSplitDataset(dataset);
@@ -84,7 +85,7 @@ export const SeriesChart: React.FunctionComponent<SeriesChartProps> = props => {
       {({ yScale, lineStage }) => <React.Fragment>
         {continuousSplitDataset.data.map((datum, index) => {
           const splitKey = nominalSplit.selectValue(datum);
-          const color = NORMAL_COLORS[index];
+          const color = visualizationColors.series[index];
           return <ColoredSeriesChartLine
             key={String(splitKey)}
             xScale={xScale}

--- a/src/client/visualizations/line-chart/charts/charts-per-series/series-hover-content.tsx
+++ b/src/client/visualizations/line-chart/charts/charts-per-series/series-hover-content.tsx
@@ -17,13 +17,14 @@
 import { Dataset, Datum, PlywoodRange } from "plywood";
 import React from "react";
 import { ReactNode } from "react";
-import { NORMAL_COLORS } from "../../../../../common/models/colors/colors";
+import { VisualizationColors } from "../../../../../common/models/colors/colors";
 import { Essence } from "../../../../../common/models/essence/essence";
 import { ConcreteSeries } from "../../../../../common/models/series/concrete-series";
 import { ColorEntry, createColorEntry } from "../../../../components/color-swabs/color-entry";
 import { ColorSwabs } from "../../../../components/color-swabs/color-swabs";
 import { SeriesBubbleContent } from "../../../../components/series-bubble-content/series-bubble-content";
 import { selectSplitDataset } from "../../../../utils/dataset/selectors/selectors";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { getContinuousDimension, getContinuousReference, getNominalSplit, hasNominalSplit } from "../../utils/splits";
 
 function findSplitDatumByAttribute(d: Datum, dimensionName: string, range: PlywoodRange): Datum {
@@ -39,14 +40,14 @@ function measureLabel(dataset: Dataset, range: PlywoodRange, series: ConcreteSer
   return <SeriesBubbleContent series={series} datum={datum} showPrevious={essence.hasComparison()}/>;
 }
 
-function colorEntries(dataset: Dataset, range: PlywoodRange, series: ConcreteSeries, essence: Essence): ColorEntry[] {
+function colorEntries(dataset: Dataset, range: PlywoodRange, series: ConcreteSeries, essence: Essence, visualizationColors: VisualizationColors): ColorEntry[] {
   const { data } = dataset;
   const nominalSplit = getNominalSplit(essence);
   const continuousRef = getContinuousReference(essence);
   const hasComparison = essence.hasComparison();
   return data.map((datum, i) => {
     const name = String(nominalSplit.selectValue(datum));
-    const color = NORMAL_COLORS[i];
+    const color = visualizationColors.series[i];
     const hoverDatum = findSplitDatumByAttribute(datum, continuousRef, range);
 
     if (!hoverDatum) {
@@ -75,9 +76,10 @@ interface SeriesHoverContentProps {
 }
 
 export const SeriesHoverContent: React.FunctionComponent<SeriesHoverContentProps> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { essence, range, series, dataset } = props;
   if (hasNominalSplit(essence)) {
-    const entries = colorEntries(dataset, range, series, essence);
+    const entries = colorEntries(dataset, range, series, essence, visualizationColors);
     return <ColorSwabs colorEntries={entries} />;
   }
   return <React.Fragment>

--- a/src/client/visualizations/line-chart/charts/charts-per-split/split-chart.tsx
+++ b/src/client/visualizations/line-chart/charts/charts-per-split/split-chart.tsx
@@ -16,12 +16,12 @@
 
 import { Dataset, Datum, NumberRange, TimeRange } from "plywood";
 import React from "react";
-import { NORMAL_COLORS } from "../../../../../common/models/colors/colors";
 import { Essence } from "../../../../../common/models/essence/essence";
 import { defaultFormatter } from "../../../../../common/models/series/series-format";
 import { Stage } from "../../../../../common/models/stage/stage";
 import { Unary } from "../../../../../common/utils/functional/functional";
 import { selectSplitDataset } from "../../../../utils/dataset/selectors/selectors";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { BaseChart } from "../../base-chart/base-chart";
 import { ColoredSeriesChartLine } from "../../chart-line/colored-series-chart-line";
 import { SingletonSeriesChartLine } from "../../chart-line/singleton-series-chart-line";
@@ -47,18 +47,29 @@ interface SplitChartProps {
 }
 
 export const SplitChart: React.FunctionComponent<SplitChartProps> = props => {
-  const { chartId, interactions, visualisationStage, chartStage, essence, xScale, xTicks, selectDatum, dataset } = props;
+  const { customization: { visualizationColors } } = useSettingsContext();
+  const {
+    chartId,
+    interactions,
+    visualisationStage,
+    chartStage,
+    essence,
+    xScale,
+    xTicks,
+    selectDatum,
+    dataset
+  } = props;
   const { interaction } = interactions;
   const splitDatum = selectDatum(dataset);
   const splitDataset = selectSplitDataset(splitDatum);
 
   const series = essence.getConcreteSeries();
 
-  const label = <Label essence={essence} datum={splitDatum} />;
+  const label = <Label essence={essence} datum={splitDatum}/>;
   const hoverContent = isHover(interaction) && <SplitHoverContent
     interaction={interaction}
     essence={essence}
-    dataset={splitDataset} />;
+    dataset={splitDataset}/>;
 
   const continuousSplit = getContinuousSplit(essence);
   const getX = (d: Datum) => continuousSplit.selectValue<TimeRange | NumberRange>(d);
@@ -85,7 +96,7 @@ export const SplitChart: React.FunctionComponent<SplitChartProps> = props => {
           dataset={splitDataset.data}
           stage={lineStage}
           essence={essence}
-          series={firstSeries} />;
+          series={firstSeries}/>;
       }}
     </BaseChart>;
   }
@@ -104,7 +115,7 @@ export const SplitChart: React.FunctionComponent<SplitChartProps> = props => {
     yDomain={domain}>
     {({ yScale, lineStage }) => <React.Fragment>
       {series.toArray().map((series, index) => {
-        const color = NORMAL_COLORS[index];
+        const color = visualizationColors.series[index];
         return <ColoredSeriesChartLine
           key={series.plywoodKey()}
           xScale={xScale}
@@ -114,7 +125,7 @@ export const SplitChart: React.FunctionComponent<SplitChartProps> = props => {
           stage={lineStage}
           essence={essence}
           series={series}
-          color={color} />;
+          color={color}/>;
       })}
     </React.Fragment>}
   </BaseChart>;

--- a/src/client/visualizations/line-chart/charts/charts-per-split/split-hover-content.tsx
+++ b/src/client/visualizations/line-chart/charts/charts-per-split/split-hover-content.tsx
@@ -16,12 +16,12 @@
 
 import { Dataset, Datum } from "plywood";
 import React from "react";
-import { NORMAL_COLORS } from "../../../../../common/models/colors/colors";
 import { Essence } from "../../../../../common/models/essence/essence";
 import { ConcreteSeries } from "../../../../../common/models/series/concrete-series";
 import { createColorEntry } from "../../../../components/color-swabs/color-entry";
 import { ColorSwabs } from "../../../../components/color-swabs/color-swabs";
 import { SeriesBubbleContent } from "../../../../components/series-bubble-content/series-bubble-content";
+import { useSettingsContext } from "../../../../views/cube-view/settings-context";
 import { Hover } from "../../interactions/interaction";
 import { getContinuousReference } from "../../utils/splits";
 
@@ -38,9 +38,10 @@ interface ColoredSeriesProps {
 }
 
 const ColoredSeries: React.FunctionComponent<ColoredSeriesProps> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { datum, hasComparison, series } = props;
   const colorEntries = series.map((series, index) => {
-    const color = NORMAL_COLORS[index];
+    const color = visualizationColors.series[index];
     const name = series.title();
     return createColorEntry({ color, name, hasComparison, datum, series });
   });

--- a/src/client/visualizations/line-chart/legend/legend.tsx
+++ b/src/client/visualizations/line-chart/legend/legend.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import { NORMAL_COLORS } from "../../../../common/models/colors/colors";
+import { useSettingsContext } from "../../../views/cube-view/settings-context";
 import "./legend.scss";
 
 export interface LegendProps {
@@ -28,12 +28,13 @@ interface LegendValuesProps {
 }
 
 const LegendValues: React.FunctionComponent<LegendValuesProps> = props => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const { values } = props;
   return <div className="legend-values">
     <table className="legend-values-table">
       <tbody>
       {values.map((value, i) => {
-        const style = { background: NORMAL_COLORS[i] };
+        const style = { background: visualizationColors.series[i] };
         return <tr key={value} className="legend-value">
           <td className="legend-value-color-cell">
             <div className="legend-value-color" style={style} />

--- a/src/client/visualizations/scatterplot/point.tsx
+++ b/src/client/visualizations/scatterplot/point.tsx
@@ -19,7 +19,9 @@ import { Datum } from "plywood";
 import { ConcreteSeries } from "../../../common/models/series/concrete-series";
 import "./scatterplot.scss";
 
+import { lightMain } from "../../../common/models/colors/colors";
 import { LinearScale } from "../../utils/linear-scale/linear-scale";
+import { useSettingsContext } from "../../views/cube-view/settings-context";
 
 interface PointProps {
   datum: Datum;
@@ -35,8 +37,12 @@ const POINT_RADIUS = 3;
 const HOVER_AREA_RADIUS = 6;
 
 export const Point: React.FunctionComponent<PointProps> = ({ datum, xScale, yScale, xSeries, ySeries, setHover, resetHover }) => {
+  const { customization: { visualizationColors } } = useSettingsContext();
   const xValue = xSeries.selectValue(datum);
   const yValue = ySeries.selectValue(datum);
+
+  const stroke = visualizationColors.main;
+  const fill = lightMain(visualizationColors);
 
   return (
     <>
@@ -45,6 +51,8 @@ export const Point: React.FunctionComponent<PointProps> = ({ datum, xScale, ySca
         cy={yScale(yValue)}
         r={POINT_RADIUS}
         className="point"
+        stroke={stroke}
+        fill={fill}
       />
       <circle
         onMouseEnter={() => setHover(datum)}

--- a/src/client/visualizations/scatterplot/scatterplot.scss
+++ b/src/client/visualizations/scatterplot/scatterplot.scss
@@ -48,6 +48,7 @@
   }
 
   .point {
+    // TODO: replace with visualisationColors.main
     @include css-variable(stroke, brand);
     @include css-variable(fill, item-dimension);
   }

--- a/src/client/visualizations/scatterplot/scatterplot.scss
+++ b/src/client/visualizations/scatterplot/scatterplot.scss
@@ -47,12 +47,6 @@
     }
   }
 
-  .point {
-    // TODO: replace with visualisationColors.main
-    @include css-variable(stroke, brand);
-    @include css-variable(fill, item-dimension);
-  }
-
   .axis-title {
     position: absolute;
     font-weight: $bold;

--- a/src/common/models/app-settings/app-settings.fixtures.ts
+++ b/src/common/models/app-settings/app-settings.fixtures.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { DEFAULT_COLORS } from "../colors/colors";
 import { LOCALES } from "../locale/locale";
 import { AppSettings, ClientAppSettings } from "./app-settings";
 
@@ -25,7 +26,8 @@ export const clientAppSettings: ClientAppSettings = {
     externalViews: [],
     timezones: [],
     locale: LOCALES["en-US"],
-    messages: {}
+    messages: {},
+    visualizationColors: DEFAULT_COLORS
   },
   oauth: { status: "disabled" },
   clientTimeout: 1000
@@ -38,7 +40,8 @@ export const appSettings: AppSettings = {
     locale: LOCALES["en-US"],
     externalViews: [],
     cssVariables: {},
-    messages: {}
+    messages: {},
+    visualizationColors: DEFAULT_COLORS
   },
   oauth: { status: "disabled" },
   version: 0

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -15,19 +15,6 @@
  * limitations under the License.
  */
 
-export const NORMAL_COLORS = [
-  "#2D95CA",
-  "#EFB925",
-  "#DA4E99",
-  "#4CC873",
-  "#745CBD",
-  "#EA7136",
-  "#E68EE0",
-  "#218C35",
-  "#B0B510",
-  "#904064"
-];
-
 export const DEFAULT_SERIES_COLORS = [
   "#2D95CA",
   "#EFB925",
@@ -46,7 +33,7 @@ export const DEFAULT_MAIN_COLOR = "#FF5900";
 export const DEFAULT_COLORS: VisualizationColors = {
   main: DEFAULT_MAIN_COLOR,
   series: DEFAULT_SERIES_COLORS
-}
+};
 
 export interface VisualizationColors {
   main: string;

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -27,3 +27,28 @@ export const NORMAL_COLORS = [
   "#B0B510",
   "#904064"
 ];
+
+export const DEFAULT_SERIES_COLORS = [
+  "#2D95CA",
+  "#EFB925",
+  "#DA4E99",
+  "#4CC873",
+  "#745CBD",
+  "#EA7136",
+  "#E68EE0",
+  "#218C35",
+  "#B0B510",
+  "#904064"
+];
+
+export const DEFAULT_MAIN_COLOR = "#FF5900";
+
+export const DEFAULT_COLORS: VisualizationColors = {
+  main: DEFAULT_MAIN_COLOR,
+  series: DEFAULT_SERIES_COLORS
+}
+
+export interface VisualizationColors {
+  main: string;
+  series: Array<string>;
+}

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -39,7 +39,7 @@ export const DEFAULT_COLORS: VisualizationColors = {
 
 export interface VisualizationColors {
   main: string;
-  series: Array<string>;
+  series: string[];
 }
 
 export function lightMain(colors: VisualizationColors): string {

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { hsl, rgb } from "d3";
+
 export const DEFAULT_SERIES_COLORS = [
   "#2D95CA",
   "#EFB925",
@@ -38,4 +40,13 @@ export const DEFAULT_COLORS: VisualizationColors = {
 export interface VisualizationColors {
   main: string;
   series: Array<string>;
+}
+
+export function lightMain(colors: VisualizationColors): string {
+  return hsl(colors.main).brighter(0.3).formatHex();
+}
+
+export function alphaMain(colors: VisualizationColors): string {
+  const { r, g, b } = rgb(colors.main);
+  return `rgba(${r}, ${g}, ${b}, ${0.14})`;
 }

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -43,7 +43,7 @@ export interface VisualizationColors {
 }
 
 export function lightMain(colors: VisualizationColors): string {
-  return hsl(colors.main).brighter(0.3).formatHex();
+  return hsl(colors.main).brighter(1.3).toString();
 }
 
 export function alphaMain(colors: VisualizationColors): string {

--- a/src/common/models/customization/customization.fixtures.ts
+++ b/src/common/models/customization/customization.fixtures.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+import { DEFAULT_COLORS } from "../colors/colors";
 import { UrlShortenerContext } from "../url-shortener/url-shortener";
 import { Customization, CustomizationJS } from "./customization";
 
 export const customization: Customization = {
+  messages: {
+    dataCubeNotFound: "404: Data Cube Not Found"
+  },
+  visualizationColors: DEFAULT_COLORS,
   cssVariables: {
     "brand-selected": "orange",
     "brand": "red",

--- a/src/common/models/customization/customization.mocha.ts
+++ b/src/common/models/customization/customization.mocha.ts
@@ -18,6 +18,7 @@
 import { expect } from "chai";
 import { Timezone } from "chronoshift";
 import * as sinon from "sinon";
+import { DEFAULT_COLORS, DEFAULT_MAIN_COLOR, DEFAULT_SERIES_COLORS } from "../colors/colors";
 import * as localeModule from "../locale/locale";
 import * as urlShortenerModule from "../url-shortener/url-shortener";
 import { Customization, DEFAULT_TIMEZONES, DEFAULT_TITLE, fromConfig, serialize } from "./customization";
@@ -161,6 +162,44 @@ describe("Customization", () => {
         });
       });
     });
+
+    describe("visualizationColors", () => {
+      it("should set default colors if no colors are defined", () => {
+        const customization = fromConfig({ ...customizationJS, visualizationColors: undefined });
+
+        expect(customization).to.deep.contain({ visualizationColors: DEFAULT_COLORS });
+      });
+
+      it("should override default main color when property is defined", () => {
+        const customization = fromConfig({
+          ...customizationJS, visualizationColors: {
+            main: "foobar-color"
+          }
+        });
+
+        expect(customization).to.deep.contain({
+          visualizationColors: {
+            series: DEFAULT_SERIES_COLORS,
+            main: "foobar-color"
+          }
+        });
+      });
+
+      it("should override default series colors when property is defined", () => {
+        const customization = fromConfig({
+          ...customizationJS, visualizationColors: {
+            series: ["one fish", "two fish", "red fish", "blue fish"]
+          }
+        });
+
+        expect(customization).to.deep.contain({
+          visualizationColors: {
+            series: ["one fish", "two fish", "red fish", "blue fish"],
+            main: DEFAULT_MAIN_COLOR
+          }
+        });
+      });
+    });
   });
 
   describe("serialize", () => {
@@ -203,6 +242,16 @@ describe("Customization", () => {
       expect(serialized).to.deep.contain({ timezones: ["Europe/Warsaw", "Asia/Manila"] });
     });
 
+    it("should pass visualizationColors as is", () => {
+      const colors = { main: "fake-color", series: ["one series color"] };
+      const serialized = serialize({
+        ...customization,
+        visualizationColors: colors
+      });
+
+      expect(serialized).to.deep.contain({ visualizationColors: colors });
+    });
+
     describe("externalViews", () => {
       // TODO: Implement
     });
@@ -212,7 +261,8 @@ describe("Customization", () => {
       it("should return hasUrlShortener true if has url shortener", () => {
         const serialized = serialize({
           ...customization,
-          urlShortener: (() => {}) as any
+          urlShortener: (() => {
+          }) as any
         });
 
         expect(serialized).to.contain({ hasUrlShortener: true });

--- a/src/common/models/customization/customization.ts
+++ b/src/common/models/customization/customization.ts
@@ -88,8 +88,6 @@ const availableCssVariables = [
   "item-measure-hover",
   "item-measure-text",
   "item-measure",
-  "main-time-area",
-  "main-time-line",
   "negative",
   "pinboard-icon",
   "positive",

--- a/src/common/models/customization/customization.ts
+++ b/src/common/models/customization/customization.ts
@@ -18,7 +18,8 @@
 import { Timezone } from "chronoshift";
 import { LOGGER } from "../../logger/logger";
 import { assoc } from "../../utils/functional/functional";
-import { isTruthy } from "../../utils/general/general";
+import { isNil, isTruthy } from "../../utils/general/general";
+import { DEFAULT_COLORS, DEFAULT_MAIN_COLOR, DEFAULT_SERIES_COLORS, VisualizationColors } from "../colors/colors";
 import { ExternalView, ExternalViewValue } from "../external-view/external-view";
 import { fromConfig as localeFromConfig, Locale, LocaleJS, serialize as serializeLocale } from "../locale/locale";
 import { fromConfig as urlShortenerFromConfig, UrlShortener, UrlShortenerDef } from "../url-shortener/url-shortener";
@@ -120,6 +121,7 @@ export interface Customization {
   cssVariables: CssVariables;
   locale: Locale;
   messages: Messages;
+  visualizationColors: VisualizationColors;
 }
 
 export interface CustomizationJS {
@@ -133,6 +135,7 @@ export interface CustomizationJS {
   sentryDSN?: string;
   cssVariables?: Record<string, string>;
   messages?: Messages;
+  visualizationColors?: Partial<VisualizationColors>;
 }
 
 export interface SerializedCustomization {
@@ -144,6 +147,7 @@ export interface SerializedCustomization {
   sentryDSN?: string;
   locale: Locale;
   messages: Messages;
+  visualizationColors: VisualizationColors;
 }
 
 export interface ClientCustomization {
@@ -155,6 +159,7 @@ export interface ClientCustomization {
   sentryDSN?: string;
   locale: Locale;
   messages: Messages;
+  visualizationColors: VisualizationColors;
 }
 
 function verifyCssVariables(cssVariables: Record<string, string>): CssVariables {
@@ -169,6 +174,12 @@ function verifyCssVariables(cssVariables: Record<string, string>): CssVariables 
     .reduce((variables: CssVariables, key: string) => {
       return assoc(variables, key, cssVariables[key]);
     }, {});
+}
+
+function readVisualizationColors(config: CustomizationJS): VisualizationColors {
+  if (isNil(config.visualizationColors)) return DEFAULT_COLORS;
+
+  return { ...DEFAULT_COLORS, ...config.visualizationColors };
 }
 
 export function fromConfig(config: CustomizationJS = {}): Customization {
@@ -193,6 +204,8 @@ export function fromConfig(config: CustomizationJS = {}): Customization {
     ? configExternalViews.map(ExternalView.fromJS)
     : [];
 
+  const visualizationColors = readVisualizationColors(config);
+
   return {
     title,
     headerBackground,
@@ -203,12 +216,13 @@ export function fromConfig(config: CustomizationJS = {}): Customization {
     timezones,
     locale: localeFromConfig(locale),
     messages,
-    externalViews
+    externalViews,
+    visualizationColors
   };
 }
 
 export function serialize(customization: Customization): SerializedCustomization {
-  const { customLogoSvg, timezones, headerBackground, locale, externalViews, sentryDSN, urlShortener, messages } = customization;
+  const { customLogoSvg, timezones, headerBackground, locale, externalViews, sentryDSN, urlShortener, messages, visualizationColors } = customization;
   return {
     customLogoSvg,
     externalViews,
@@ -217,7 +231,8 @@ export function serialize(customization: Customization): SerializedCustomization
     sentryDSN,
     locale: serializeLocale(locale),
     timezones: timezones.map(t => t.toJS()),
-    messages
+    messages,
+    visualizationColors
   };
 }
 

--- a/src/common/models/essence/essence.fixtures.ts
+++ b/src/common/models/essence/essence.fixtures.ts
@@ -21,9 +21,23 @@ import { HEAT_MAP_MANIFEST } from "../../visualization-manifests/heat-map/heat-m
 import { LINE_CHART_MANIFEST } from "../../visualization-manifests/line-chart/line-chart";
 import { TABLE_MANIFEST } from "../../visualization-manifests/table/table";
 import { TOTALS_MANIFEST } from "../../visualization-manifests/totals/totals";
+import { clientAppSettings } from "../app-settings/app-settings.fixtures";
 import { customClientCube, twitterClientDataCube, wikiClientDataCube } from "../data-cube/data-cube.fixtures";
-import { NumberFilterClause, NumberRange, RelativeTimeFilterClause, TimeFilterPeriod } from "../filter-clause/filter-clause";
-import { boolean, numberRange, stringContains, stringIn, stringMatch, timePeriod, timeRange } from "../filter-clause/filter-clause.fixtures";
+import {
+  NumberFilterClause,
+  NumberRange,
+  RelativeTimeFilterClause,
+  TimeFilterPeriod
+} from "../filter-clause/filter-clause";
+import {
+  boolean,
+  numberRange,
+  stringContains,
+  stringIn,
+  stringMatch,
+  timePeriod,
+  timeRange
+} from "../filter-clause/filter-clause.fixtures";
 import { Filter } from "../filter/filter";
 import { EMPTY_SERIES, SeriesList } from "../series-list/series-list";
 import { measureSeries } from "../series/series.fixtures";
@@ -35,6 +49,7 @@ import { VisualizationManifest } from "../visualization-manifest/visualization-m
 import { Essence, EssenceValue, VisStrategy } from "./essence";
 
 const defaultEssence: EssenceValue = {
+  appSettings: clientAppSettings,
   dataCube: customClientCube("essence-fixture-data-cube", "essence-fixture-data-cube"),
   visualization: null,
   visualizationSettings: null,
@@ -96,6 +111,7 @@ export class EssenceFixtures {
       stringSplitCombine("namespace", { sort: { reference: "added", direction: SortDirection.descending }, limit: 5 })
     ];
     return new Essence({
+      appSettings: clientAppSettings,
       dataCube: wikiClientDataCube,
       visualization: HEAT_MAP_MANIFEST,
       visualizationSettings: HEAT_MAP_MANIFEST.visualizationSettings.defaults,
@@ -130,6 +146,7 @@ export class EssenceFixtures {
       measureSeries("added")
     ];
     return new Essence({
+      appSettings: clientAppSettings,
       dataCube: wikiClientDataCube,
       visualization: TABLE_MANIFEST as unknown as VisualizationManifest,
       visualizationSettings: TABLE_MANIFEST.visualizationSettings.defaults,
@@ -158,6 +175,7 @@ export class EssenceFixtures {
       measureSeries("added")
     ];
     return new Essence({
+      appSettings: clientAppSettings,
       dataCube: wikiClientDataCube,
       visualization: LINE_CHART_MANIFEST as unknown as VisualizationManifest,
       visualizationSettings: LINE_CHART_MANIFEST.visualizationSettings.defaults,

--- a/src/common/models/essence/essence.mocha.ts
+++ b/src/common/models/essence/essence.mocha.ts
@@ -22,6 +22,7 @@ import { GRID_MANIFEST } from "../../visualization-manifests/grid/grid";
 import { LINE_CHART_MANIFEST } from "../../visualization-manifests/line-chart/line-chart";
 import { TABLE_MANIFEST } from "../../visualization-manifests/table/table";
 import { TOTALS_MANIFEST } from "../../visualization-manifests/totals/totals";
+import { clientAppSettings } from "../app-settings/app-settings.fixtures";
 import { twitterClientDataCube } from "../data-cube/data-cube.fixtures";
 import { TimeFilterPeriod } from "../filter-clause/filter-clause";
 import { timePeriod } from "../filter-clause/filter-clause.fixtures";
@@ -33,6 +34,7 @@ import { DimensionSort, SortDirection } from "../sort/sort";
 import { Split, SplitType } from "../split/split";
 import { Splits } from "../splits/splits";
 import { TimeShift } from "../time-shift/time-shift";
+import { VisualizationManifest } from "../visualization-manifest/visualization-manifest";
 import { Essence, VisStrategy } from "./essence";
 import { EssenceFixtures } from "./essence.fixtures";
 
@@ -41,7 +43,7 @@ describe("EssenceProps", () => {
 
   describe(".fromDataCube", () => {
     it.skip("works in the base case", () => {
-      const essence = Essence.fromDataCube(dataCube);
+      const essence = Essence.fromDataCube(dataCube, clientAppSettings);
 
       // TODO: don't test toJS
       expect(essence.toJS()).to.deep.equal({
@@ -135,7 +137,7 @@ describe("EssenceProps", () => {
             sort: new DimensionSort({ reference: "time", direction: SortDirection.ascending })
           })],
           series,
-          current: null,
+          current: null as VisualizationManifest,
           expected: LINE_CHART_MANIFEST
         }
       ];
@@ -143,6 +145,7 @@ describe("EssenceProps", () => {
       tests.forEach(({ splits, current, series, expected }) => {
         it(`chooses ${expected.name} given splits: [${splits}] with current ${current && current.name}`, () => {
           const { visualization } = Essence.getBestVisualization(
+            clientAppSettings,
             twitterClientDataCube,
             Splits.fromSplits(splits),
             SeriesList.fromSeries(series),
@@ -269,7 +272,7 @@ describe("EssenceProps", () => {
     describe("#changeVisualisation", () => {
       [TABLE_MANIFEST, LINE_CHART_MANIFEST, BAR_CHART_MANIFEST].forEach(manifest => {
         it("it sets visResolve to manual", () => {
-          const essence = EssenceFixtures.twitterNoVisualisation().changeVisualization(manifest);
+          const essence = EssenceFixtures.twitterNoVisualisation().changeVisualization(manifest as VisualizationManifest);
           expect(essence.visualization.name).to.deep.equal(manifest.name);
           expect(essence.visResolve.isManual()).to.be.true;
         });

--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -618,9 +618,10 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
       .resolveVisualizationAndUpdate();
   }
 
+  // NOTE: Pass appsettings to all callers. Probably all callers are from Clicker object
   public resolveVisualizationAndUpdate() {
     const { visualization, splits, dataCube, series, appSettings } = this;
-    const result = resolveVisualization({ appSettings, splits, dataCube, visualization, series });
+    const result = resolveVisualization({ appSettings, dataCube, visualization, splits, series });
     return this
       .set("visResolve", result.visResolve)
       .set("visualization", result.visualization)

--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -17,11 +17,13 @@
 
 import { Timezone } from "chronoshift";
 import { List, OrderedSet, Record as ImmutableRecord, Set } from "immutable";
-import { serialize } from "../../../client/deserializers/data-cube";
+import { serialize as serializeAppSettings } from "../../../client/deserializers/app-settings";
+import { serialize as serializeDataCube } from "../../../client/deserializers/data-cube";
 import { thread } from "../../utils/functional/functional";
 import nullableEquals from "../../utils/immutable-utils/nullable-equals";
 import { visualizationIndependentEvaluator } from "../../utils/rules/visualization-independent-evaluator";
 import { MANIFESTS } from "../../visualization-manifests";
+import { ClientAppSettings } from "../app-settings/app-settings";
 import {
   ClientDataCube,
   getDefaultFilter,
@@ -78,6 +80,7 @@ export enum VisStrategy {
 type DimensionId = string;
 
 export interface EssenceValue {
+  appSettings: ClientAppSettings;
   dataCube: ClientDataCube;
   visualization: VisualizationManifest;
   visualizationSettings: VisualizationSettings | null;
@@ -92,6 +95,7 @@ export interface EssenceValue {
 }
 
 const defaultEssence: EssenceValue = {
+  appSettings: null,
   dataCube: null,
   visualization: null,
   visualizationSettings: null,
@@ -111,18 +115,18 @@ export interface EffectiveFilterOptions {
 }
 
 type VisualizationResolverResult = Pick<EssenceValue, "splits" | "visualization" | "visResolve">;
-type VisualizationResolverParameters = Pick<EssenceValue, "visualization" | "dataCube" | "splits" | "series">;
+type VisualizationResolverParameters = Pick<EssenceValue, "visualization" | "dataCube" | "splits" | "series" | "appSettings">;
 
-function resolveVisualization({ visualization, dataCube, splits, series }: VisualizationResolverParameters): VisualizationResolverResult {
+function resolveVisualization({ visualization, dataCube, splits, series, appSettings }: VisualizationResolverParameters): VisualizationResolverResult {
 
   let visResolve: Resolve;
   // Place vis here because it needs to know about splits and colors (and maybe later other things)
   if (!visualization) {
-    const visAndResolve = Essence.getBestVisualization(dataCube, splits, series, null);
+    const visAndResolve = Essence.getBestVisualization(appSettings, dataCube, splits, series, null);
     visualization = visAndResolve.visualization;
   }
 
-  const ruleVariables = { dataCube, series, splits, isSelectedVisualization: true };
+  const ruleVariables = { appSettings, dataCube, series, splits, isSelectedVisualization: true };
   visResolve = visualization.evaluateRules(ruleVariables);
   if (visResolve.isAutomatic()) {
     const adjustment = visResolve.adjustment;
@@ -143,6 +147,7 @@ function resolveVisualization({ visualization, dataCube, splits, series }: Visua
 export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
 
   static getBestVisualization(
+    appSettings: ClientAppSettings,
     dataCube: ClientDataCube,
     splits: Splits,
     series: SeriesList,
@@ -150,7 +155,7 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
   ): VisualizationAndResolve {
     const visAndResolves = MANIFESTS.map(visualization => {
       const isSelectedVisualization = visualization === currentVisualization;
-      const ruleVariables = { dataCube, splits, series, isSelectedVisualization };
+      const ruleVariables = { appSettings, dataCube, splits, series, isSelectedVisualization };
       return {
         visualization,
         resolve: visualization.evaluateRules(ruleVariables)
@@ -160,8 +165,9 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
     return visAndResolves.sort((vr1, vr2) => Resolve.compare(vr1.resolve, vr2.resolve))[0];
   }
 
-  static fromDataCube(dataCube: ClientDataCube): Essence {
+  static fromDataCube(dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
     const essence = new Essence({
+      appSettings,
       dataCube,
       visualization: null,
       visualizationSettings: null,
@@ -238,9 +244,10 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
 
   public toJS() {
     return {
+      appSettings: serializeAppSettings(this.appSettings),
       visualization: this.visualization,
       visualizationSettings: this.visualizationSettings,
-      dataCube: serialize(this.dataCube),
+      dataCube: serializeDataCube(this.dataCube),
       timezone: this.timezone.toJS(),
       filter: this.filter && this.filter.toJS(),
       splits: this.splits && this.splits.toJS(),
@@ -435,9 +442,9 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
     }
 
     function adjustVisualization(essence: Essence): Essence {
-      const { dataCube, visualization, splits, series } = essence;
+      const { dataCube, visualization, splits, series, appSettings } = essence;
       const { visualization: newVis } = Essence.getBestVisualization(
-        dataCube, splits, series, visualization);
+        appSettings, dataCube, splits, series, visualization);
       if (newVis === visualization) return essence;
       return essence.changeVisualization(newVis, newVis.visualizationSettings.defaults);
     }
@@ -501,7 +508,7 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
   }
 
   public changeSplits(splits: Splits, strategy: VisStrategy): Essence {
-    const { splits: oldSplits, dataCube, visualization, visResolve, filter, series } = this;
+    const { splits: oldSplits, appSettings, dataCube, visualization, visResolve, filter, series } = this;
 
     const newSplits = this.setSortOnSplits(splits).updateWithFilter(filter, dataCube.dimensions);
 
@@ -518,7 +525,7 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
 
     function adjustVisualization(essence: Essence): Essence {
       if (adjustStrategy(strategy) !== VisStrategy.FairGame) return essence;
-      const { visualization: newVis } = Essence.getBestVisualization(dataCube, newSplits, series, visualization);
+      const { visualization: newVis } = Essence.getBestVisualization(appSettings, dataCube, newSplits, series, visualization);
       if (newVis === visualization) return essence;
       return essence.changeVisualization(newVis, newVis.visualizationSettings.defaults);
     }
@@ -612,8 +619,8 @@ export class Essence extends ImmutableRecord<EssenceValue>(defaultEssence) {
   }
 
   public resolveVisualizationAndUpdate() {
-    const { visualization, splits, dataCube, series } = this;
-    const result = resolveVisualization({ splits, dataCube, visualization, series });
+    const { visualization, splits, dataCube, series, appSettings } = this;
+    const result = resolveVisualization({ appSettings, splits, dataCube, visualization, series });
     return this
       .set("visResolve", result.visResolve)
       .set("visualization", result.visualization)

--- a/src/common/utils/rules/split-adjustments.mocha.ts
+++ b/src/common/utils/rules/split-adjustments.mocha.ts
@@ -16,6 +16,7 @@
 
 import { expect } from "chai";
 import { $ } from "plywood";
+import { DEFAULT_COLORS } from "../../models/colors/colors";
 import { createDimension, Dimension } from "../../models/dimension/dimension";
 import { SeriesList } from "../../models/series-list/series-list";
 import { measureSeries } from "../../models/series/series.fixtures";
@@ -28,7 +29,6 @@ import {
   adjustLimit,
   adjustSort
 } from "./split-adjustments";
-import { DEFAULT_COLORS } from "../../models/colors/colors";
 
 describe("Split adjustment utilities", () => {
   describe("adjustContinuousTimeSplit", () => {

--- a/src/common/utils/rules/split-adjustments.mocha.ts
+++ b/src/common/utils/rules/split-adjustments.mocha.ts
@@ -28,6 +28,7 @@ import {
   adjustLimit,
   adjustSort
 } from "./split-adjustments";
+import { DEFAULT_COLORS } from "../../models/colors/colors";
 
 describe("Split adjustment utilities", () => {
   describe("adjustContinuousTimeSplit", () => {
@@ -118,7 +119,7 @@ describe("Split adjustment utilities", () => {
         limits: [42, 100]
       };
       const split = stringSplitCombine("foobar", { limit: 50 });
-      const adjusted = adjustColorSplit(split, dimension, SeriesList.fromSeries([]));
+      const adjusted = adjustColorSplit(split, dimension, SeriesList.fromSeries([]), DEFAULT_COLORS);
 
       expect(adjusted.limit).to.be.equal(10);
     });

--- a/src/common/utils/rules/split-adjustments.ts
+++ b/src/common/utils/rules/split-adjustments.ts
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-import { NORMAL_COLORS } from "../../models/colors/colors";
+import { VisualizationColors } from "../../models/colors/colors";
 import { Dimension } from "../../models/dimension/dimension";
 import { SeriesList } from "../../models/series-list/series-list";
 import { DimensionSort, SeriesSort, SortDirection } from "../../models/sort/sort";
 import { Split, SplitType } from "../../models/split/split";
 import { thread } from "../functional/functional";
 
-const COLORS_COUNT = NORMAL_COLORS.length;
-
-export function adjustColorSplit(split: Split, dimension: Dimension, series: SeriesList): Split {
+export function adjustColorSplit(split: Split, dimension: Dimension, series: SeriesList, visualizationColors: VisualizationColors): Split {
+  const colorsCount = visualizationColors.series.length;
   return thread(
     split,
     adjustSort(dimension, series),
     // TODO: This magic 5 will disappear in #756
-    adjustFiniteLimit([5, COLORS_COUNT], COLORS_COUNT)
+    adjustFiniteLimit([5, colorsCount], colorsCount)
   );
 }
 

--- a/src/common/utils/rules/visualization-dependent-evaluator.ts
+++ b/src/common/utils/rules/visualization-dependent-evaluator.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 import { ClientDataCube } from "../../models/data-cube/data-cube";
 import { SeriesList } from "../../models/series-list/series-list";
 import { Splits } from "../../models/splits/splits";
@@ -27,6 +28,7 @@ export interface PredicateVariables {
 }
 
 export interface ActionVariables {
+  appSettings: ClientAppSettings;
   dataCube: ClientDataCube;
   splits: Splits;
   series: SeriesList;

--- a/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
@@ -42,7 +42,7 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
@@ -59,7 +59,7 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
@@ -76,14 +76,14 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
 
       it(`is symmetric in decode/encode for ${visualization.name} in version ${version}`, () => {
         const encodedHash = urlHashConverter.toHash(essence, version);
-        const decodedEssence = urlHashConverter.essenceFromHash(encodedHash, wikiClientDataCube, clientAppSettings);
+        const decodedEssence = urlHashConverter.essenceFromHash(encodedHash, clientAppSettings, wikiClientDataCube);
 
         expect(essence.toJS()).to.deep.equal(decodedEssence.toJS());
       });
@@ -94,7 +94,7 @@ describe("urlHashConverter", () => {
       }
 
       it(`is symmetric in encode/decode for ${visualization.name} in version ${version}`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
         const encodedHash = urlHashConverter.toHash(decodedEssence, version);
 
         try {
@@ -116,7 +116,7 @@ describe("urlHashConverter", () => {
 
   minimalNumberOfSegmentsTests.forEach(({ version, hash }) => {
     it(`decodes version ${version} with minimal number of segments`, () => {
-      const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+      const decodedEssence = urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
 
       expect(decodedEssence).to.be.an.instanceOf(Essence);
     });
@@ -131,7 +131,7 @@ describe("urlHashConverter", () => {
 
   wrongHashStructureTests.forEach(({ hash, errorMessage }) => {
     it(`throws error for hash: "${hash}" with wrong structure`, () => {
-      const essenceFromHashCall = () => urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
+      const essenceFromHashCall = () => urlHashConverter.essenceFromHash(hash, clientAppSettings, wikiClientDataCube);
       expect(essenceFromHashCall).to.throw(errorMessage);
     });
   });

--- a/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from "chai";
+import { clientAppSettings } from "../../models/app-settings/app-settings.fixtures";
 import { wikiClientDataCube } from "../../models/data-cube/data-cube.fixtures";
 import { Essence } from "../../models/essence/essence";
 import { EssenceFixtures } from "../../models/essence/essence.fixtures";
@@ -22,7 +23,6 @@ import { ViewDefinitionVersion } from "../../view-definitions";
 import { hashToObject } from "../../view-definitions/hash-conversions";
 import { getHashSegments, urlHashConverter } from "./url-hash-converter";
 import { UrlHashConverterFixtures } from "./url-hash-converter.fixtures";
-import { clientAppSettings } from "../../models/app-settings/app-settings.fixtures";
 
 interface HashEssenceCase {
   version: ViewDefinitionVersion;

--- a/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.mocha.ts
@@ -22,6 +22,7 @@ import { ViewDefinitionVersion } from "../../view-definitions";
 import { hashToObject } from "../../view-definitions/hash-conversions";
 import { getHashSegments, urlHashConverter } from "./url-hash-converter";
 import { UrlHashConverterFixtures } from "./url-hash-converter.fixtures";
+import { clientAppSettings } from "../../models/app-settings/app-settings.fixtures";
 
 interface HashEssenceCase {
   version: ViewDefinitionVersion;
@@ -41,7 +42,7 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
@@ -58,7 +59,7 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
@@ -75,14 +76,14 @@ describe("urlHashConverter", () => {
       const { visualization } = essence;
 
       it(`decodes ${visualization.name} version ${version} correctly`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
 
         expect(decodedEssence.toJS()).to.deep.equal(essence.toJS());
       });
 
       it(`is symmetric in decode/encode for ${visualization.name} in version ${version}`, () => {
         const encodedHash = urlHashConverter.toHash(essence, version);
-        const decodedEssence = urlHashConverter.essenceFromHash(encodedHash, wikiClientDataCube);
+        const decodedEssence = urlHashConverter.essenceFromHash(encodedHash, wikiClientDataCube, clientAppSettings);
 
         expect(essence.toJS()).to.deep.equal(decodedEssence.toJS());
       });
@@ -93,7 +94,7 @@ describe("urlHashConverter", () => {
       }
 
       it(`is symmetric in encode/decode for ${visualization.name} in version ${version}`, () => {
-        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+        const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
         const encodedHash = urlHashConverter.toHash(decodedEssence, version);
 
         try {
@@ -115,7 +116,7 @@ describe("urlHashConverter", () => {
 
   minimalNumberOfSegmentsTests.forEach(({ version, hash }) => {
     it(`decodes version ${version} with minimal number of segments`, () => {
-      const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+      const decodedEssence = urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
 
       expect(decodedEssence).to.be.an.instanceOf(Essence);
     });
@@ -130,7 +131,7 @@ describe("urlHashConverter", () => {
 
   wrongHashStructureTests.forEach(({ hash, errorMessage }) => {
     it(`throws error for hash: "${hash}" with wrong structure`, () => {
-      const essenceFromHashCall = () => urlHashConverter.essenceFromHash(hash, wikiClientDataCube);
+      const essenceFromHashCall = () => urlHashConverter.essenceFromHash(hash, wikiClientDataCube, clientAppSettings);
       expect(essenceFromHashCall).to.throw(errorMessage);
     });
   });

--- a/src/common/utils/url-hash-converter/url-hash-converter.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.ts
@@ -31,7 +31,7 @@ const SEGMENT_SEPARATOR = "/";
 const MINIMAL_HASH_SEGMENTS_COUNT = 2;
 
 export interface UrlHashConverter {
-  essenceFromHash(hash: string, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence;
+  essenceFromHash(hash: string, appSettings: ClientAppSettings, dataCube: ClientDataCube): Essence;
 
   toHash(essence: Essence, version?: ViewDefinitionVersion): string;
 }
@@ -86,14 +86,14 @@ export function getHashSegments(hash: string): HashSegments {
 }
 
 export const urlHashConverter: UrlHashConverter = {
-  essenceFromHash(hash: string, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
+  essenceFromHash(hash: string, appSettings: ClientAppSettings, dataCube: ClientDataCube): Essence {
     const { version, encodedModel, visualization } = getHashSegments(hash);
 
     const urlEncoder = definitionUrlEncoders[version];
     const definitionConverter = definitionConverters[version];
 
     const definition = urlEncoder.decodeUrlHash(encodedModel, visualization);
-    return definitionConverter.fromViewDefinition(definition, dataCube, appSettings);
+    return definitionConverter.fromViewDefinition(definition, appSettings, dataCube);
   },
 
   toHash(essence: Essence, version: ViewDefinitionVersion = DEFAULT_VIEW_DEFINITION_VERSION): string {

--- a/src/common/utils/url-hash-converter/url-hash-converter.ts
+++ b/src/common/utils/url-hash-converter/url-hash-converter.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 import { ClientDataCube } from "../../models/data-cube/data-cube";
 import { Essence } from "../../models/essence/essence";
 import { Visualization } from "../../models/visualization-manifest/visualization-manifest";
@@ -30,7 +31,7 @@ const SEGMENT_SEPARATOR = "/";
 const MINIMAL_HASH_SEGMENTS_COUNT = 2;
 
 export interface UrlHashConverter {
-  essenceFromHash(hash: string, dataCube: ClientDataCube): Essence;
+  essenceFromHash(hash: string, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence;
 
   toHash(essence: Essence, version?: ViewDefinitionVersion): string;
 }
@@ -85,14 +86,14 @@ export function getHashSegments(hash: string): HashSegments {
 }
 
 export const urlHashConverter: UrlHashConverter = {
-  essenceFromHash(hash: string, dataCube: ClientDataCube): Essence {
+  essenceFromHash(hash: string, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
     const { version, encodedModel, visualization } = getHashSegments(hash);
 
     const urlEncoder = definitionUrlEncoders[version];
     const definitionConverter = definitionConverters[version];
 
     const definition = urlEncoder.decodeUrlHash(encodedModel, visualization);
-    return definitionConverter.fromViewDefinition(definition, dataCube);
+    return definitionConverter.fromViewDefinition(definition, dataCube, appSettings);
   },
 
   toHash(essence: Essence, version: ViewDefinitionVersion = DEFAULT_VIEW_DEFINITION_VERSION): string {

--- a/src/common/view-definitions/test/essence.fixture.ts
+++ b/src/common/view-definitions/test/essence.fixture.ts
@@ -16,6 +16,7 @@
 
 import { day, Duration, Timezone } from "chronoshift";
 import { OrderedSet } from "immutable";
+import { clientAppSettings } from "../../models/app-settings/app-settings.fixtures";
 import { Essence, EssenceValue } from "../../models/essence/essence";
 import { RelativeTimeFilterClause, TimeFilterPeriod } from "../../models/filter-clause/filter-clause";
 import { Filter } from "../../models/filter/filter";
@@ -61,6 +62,7 @@ const defaults: EssenceOptions = {
 
 export function mockEssence(opts: Partial<EssenceOptions> = {}) {
   return new Essence({
+    appSettings: clientAppSettings,
     dataCube,
     ...defaults,
     ...opts

--- a/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.mocha.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from "chai";
+import { clientAppSettings } from "../../models/app-settings/app-settings.fixtures";
 import { wikiClientDataCube } from "../../models/data-cube/data-cube.fixtures";
 import { TimeFilterPeriod } from "../../models/filter-clause/filter-clause";
 import { stringIn, timePeriod } from "../../models/filter-clause/filter-clause.fixtures";
@@ -64,7 +65,7 @@ describe("ViewDefinitionConverter2", () => {
   ].forEach(({ label, expression, period }) => {
     it(`converts ${label} bucket expression to time period`, () => {
       const viewDefinition = ViewDefinitionConverter2Fixtures.withFilterExpression(expression);
-      const essence = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, wikiClientDataCube);
+      const essence = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, clientAppSettings, wikiClientDataCube);
       const convertedClause = essence.filter.clauses.first();
 
       const expectedClause = timePeriod("time", "P1D", period);
@@ -125,7 +126,7 @@ describe("ViewDefinitionConverter2", () => {
         }
       }
     ]);
-    const convertedFilter = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, wikiClientDataCube).filter;
+    const convertedFilter = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, clientAppSettings, wikiClientDataCube).filter;
     const convertedClause = convertedFilter.clauses.get(1);
 
     const expectedClause = stringIn("page_last_author", ["TypeScript"]);
@@ -160,7 +161,7 @@ describe("ViewDefinitionConverter2", () => {
         limit: 10
       }
     }]);
-    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, wikiClientDataCube).splits;
+    const convertedSplits = new ViewDefinitionConverter2().fromViewDefinition(viewDefinition, clientAppSettings, wikiClientDataCube).splits;
 
     expect(convertedSplits.getSplit(0).reference).to.equal("page_last_author");
   });

--- a/src/common/view-definitions/version-2/view-definition-converter-2.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.ts
@@ -66,7 +66,7 @@ export type FilterSelection = Expression | string;
 export class ViewDefinitionConverter2 implements ViewDefinitionConverter<ViewDefinition2, Essence> {
   version = 2;
 
-  fromViewDefinition(definition: ViewDefinition2, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
+  fromViewDefinition(definition: ViewDefinition2, appSettings: ClientAppSettings, dataCube: ClientDataCube): Essence {
     const visualization = manifestByName(definition.visualization);
     const visualizationSettings = visualization.visualizationSettings.defaults;
 

--- a/src/common/view-definitions/version-2/view-definition-converter-2.ts
+++ b/src/common/view-definitions/version-2/view-definition-converter-2.ts
@@ -33,6 +33,7 @@ import {
   TimeRange,
   TimeRangeExpression
 } from "plywood";
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 import { ClientDataCube } from "../../models/data-cube/data-cube";
 import { DateRange } from "../../models/date-range/date-range";
 import { Dimension } from "../../models/dimension/dimension";
@@ -65,7 +66,7 @@ export type FilterSelection = Expression | string;
 export class ViewDefinitionConverter2 implements ViewDefinitionConverter<ViewDefinition2, Essence> {
   version = 2;
 
-  fromViewDefinition(definition: ViewDefinition2, dataCube: ClientDataCube): Essence {
+  fromViewDefinition(definition: ViewDefinition2, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
     const visualization = manifestByName(definition.visualization);
     const visualizationSettings = visualization.visualizationSettings.defaults;
 
@@ -79,6 +80,7 @@ export class ViewDefinitionConverter2 implements ViewDefinitionConverter<ViewDef
     const pinnedSort = definition.pinnedSort;
 
     return new Essence({
+      appSettings,
       dataCube,
       visualization,
       visualizationSettings,

--- a/src/common/view-definitions/version-3/view-definition-converter-3.ts
+++ b/src/common/view-definitions/version-3/view-definition-converter-3.ts
@@ -32,7 +32,7 @@ import { ViewDefinition3 } from "./view-definition-3";
 export class ViewDefinitionConverter3 implements ViewDefinitionConverter<ViewDefinition3, Essence> {
   version = 3;
 
-  fromViewDefinition(definition: ViewDefinition3, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
+  fromViewDefinition(definition: ViewDefinition3, appSettings: ClientAppSettings, dataCube: ClientDataCube): Essence {
     const timezone = Timezone.fromJS(definition.timezone);
 
     const visualization = manifestByName(definition.visualization);

--- a/src/common/view-definitions/version-3/view-definition-converter-3.ts
+++ b/src/common/view-definitions/version-3/view-definition-converter-3.ts
@@ -16,6 +16,7 @@
 
 import { Timezone } from "chronoshift";
 import { List, OrderedSet } from "immutable";
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 import { ClientDataCube } from "../../models/data-cube/data-cube";
 import { Essence } from "../../models/essence/essence";
 import { Filter } from "../../models/filter/filter";
@@ -31,7 +32,7 @@ import { ViewDefinition3 } from "./view-definition-3";
 export class ViewDefinitionConverter3 implements ViewDefinitionConverter<ViewDefinition3, Essence> {
   version = 3;
 
-  fromViewDefinition(definition: ViewDefinition3, dataCube: ClientDataCube): Essence {
+  fromViewDefinition(definition: ViewDefinition3, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
     const timezone = Timezone.fromJS(definition.timezone);
 
     const visualization = manifestByName(definition.visualization);
@@ -48,6 +49,7 @@ export class ViewDefinitionConverter3 implements ViewDefinitionConverter<ViewDef
     const series = seriesDefinitionConverter.toEssenceSeries(definition.measures, dataCube.measures);
 
     return new Essence({
+      appSettings,
       dataCube,
       visualization,
       visualizationSettings,

--- a/src/common/view-definitions/version-4/test/utils.ts
+++ b/src/common/view-definitions/version-4/test/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { clientAppSettings } from "../../../models/app-settings/app-settings.fixtures";
 import { Essence } from "../../../models/essence/essence";
 import { assertEqlEssence } from "../../test/assertions";
 import { dataCube } from "../../test/data-cube.fixture";
@@ -21,7 +22,7 @@ import { ViewDefinition4 } from "../view-definition-4";
 import { ViewDefinitionConverter4 } from "../view-definition-converter-4";
 
 const converter = new ViewDefinitionConverter4();
-export const toEssence = (viewDef: ViewDefinition4) => converter.fromViewDefinition(viewDef, dataCube);
+export const toEssence = (viewDef: ViewDefinition4) => converter.fromViewDefinition(viewDef, clientAppSettings, dataCube);
 
 export function assertConversionToEssence(viewDef: ViewDefinition4, essence: Essence) {
   assertEqlEssence(toEssence(viewDef), essence);

--- a/src/common/view-definitions/version-4/view-definition-converter-4.ts
+++ b/src/common/view-definitions/version-4/view-definition-converter-4.ts
@@ -34,7 +34,7 @@ import { fromViewDefinition, toViewDefinition } from "./visualization-settings-c
 export class ViewDefinitionConverter4 implements ViewDefinitionConverter<ViewDefinition4, Essence> {
   version = 4;
 
-  fromViewDefinition(definition: ViewDefinition4, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
+  fromViewDefinition(definition: ViewDefinition4, appSettings: ClientAppSettings, dataCube: ClientDataCube): Essence {
     const timezone = Timezone.fromJS(definition.timezone);
 
     const visualization = manifestByName(definition.visualization);

--- a/src/common/view-definitions/version-4/view-definition-converter-4.ts
+++ b/src/common/view-definitions/version-4/view-definition-converter-4.ts
@@ -16,6 +16,7 @@
 
 import { Timezone } from "chronoshift";
 import { List, OrderedSet } from "immutable";
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 import { ClientDataCube } from "../../models/data-cube/data-cube";
 import { Essence } from "../../models/essence/essence";
 import { Filter } from "../../models/filter/filter";
@@ -29,7 +30,6 @@ import { seriesDefinitionConverter } from "./series-definition";
 import { splitConverter } from "./split-definition";
 import { ViewDefinition4 } from "./view-definition-4";
 import { fromViewDefinition, toViewDefinition } from "./visualization-settings-converter";
-import { ClientAppSettings } from "../../models/app-settings/app-settings";
 
 export class ViewDefinitionConverter4 implements ViewDefinitionConverter<ViewDefinition4, Essence> {
   version = 4;

--- a/src/common/view-definitions/version-4/view-definition-converter-4.ts
+++ b/src/common/view-definitions/version-4/view-definition-converter-4.ts
@@ -29,11 +29,12 @@ import { seriesDefinitionConverter } from "./series-definition";
 import { splitConverter } from "./split-definition";
 import { ViewDefinition4 } from "./view-definition-4";
 import { fromViewDefinition, toViewDefinition } from "./visualization-settings-converter";
+import { ClientAppSettings } from "../../models/app-settings/app-settings";
 
 export class ViewDefinitionConverter4 implements ViewDefinitionConverter<ViewDefinition4, Essence> {
   version = 4;
 
-  fromViewDefinition(definition: ViewDefinition4, dataCube: ClientDataCube): Essence {
+  fromViewDefinition(definition: ViewDefinition4, dataCube: ClientDataCube, appSettings: ClientAppSettings): Essence {
     const timezone = Timezone.fromJS(definition.timezone);
 
     const visualization = manifestByName(definition.visualization);
@@ -69,6 +70,7 @@ export class ViewDefinitionConverter4 implements ViewDefinitionConverter<ViewDef
     const series = seriesDefinitionConverter.toEssenceSeries(definition.series, dataCube.measures);
 
     return new Essence({
+      appSettings,
       dataCube,
       visualization,
       visualizationSettings,

--- a/src/common/view-definitions/view-definition-converter.ts
+++ b/src/common/view-definitions/view-definition-converter.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { ClientAppSettings } from "../models/app-settings/app-settings";
 import { ClientDataCube } from "../models/data-cube/data-cube";
 import { Essence } from "../models/essence/essence";
 
 export interface ViewDefinitionConverter<VD extends object, E extends Essence> {
   version: number;
 
-  fromViewDefinition(definition: VD, dataCube: ClientDataCube): E;
+  fromViewDefinition(definition: VD, dataCube: ClientDataCube, appSettings: ClientAppSettings): E;
 
   toViewDefinition(essence: E): VD;
 }

--- a/src/common/view-definitions/view-definition-converter.ts
+++ b/src/common/view-definitions/view-definition-converter.ts
@@ -21,7 +21,7 @@ import { Essence } from "../models/essence/essence";
 export interface ViewDefinitionConverter<VD extends object, E extends Essence> {
   version: number;
 
-  fromViewDefinition(definition: VD, dataCube: ClientDataCube, appSettings: ClientAppSettings): E;
+  fromViewDefinition(definition: VD, appSettings: ClientAppSettings, dataCube: ClientDataCube): E;
 
   toViewDefinition(essence: E): VD;
 }

--- a/src/common/visualization-manifests/bar-chart/bar-chart.ts
+++ b/src/common/visualization-manifests/bar-chart/bar-chart.ts
@@ -49,7 +49,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
   })
 
   .when(Predicates.areExactSplitKinds("time", "*"))
-  .then(({ splits, series, dataCube }) => {
+  .then(({ splits, series, dataCube, appSettings }) => {
     const timeSplit = splits.getSplit(0);
     const nominalSplit = splits.getSplit(1);
     const nominalDimension = findDimensionByName(dataCube.dimensions, nominalSplit.reference);
@@ -58,21 +58,21 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
       // Switch splits in place and conform
       splits: new Splits({
         splits: List([
-          adjustColorSplit(nominalSplit, nominalDimension, series),
+          adjustColorSplit(nominalSplit, nominalDimension, series, appSettings.customization.visualizationColors),
           adjustContinuousTimeSplit(timeSplit)
         ])
       })
     });
   })
   .when(Predicates.areExactSplitKinds("*", "time"))
-  .then(({ splits, series, dataCube, isSelectedVisualization }) => {
+  .then(({ splits, series, dataCube, isSelectedVisualization, appSettings }) => {
     const timeSplit = splits.getSplit(1);
     const nominalSplit = splits.getSplit(0);
     const nominalDimension = findDimensionByName(dataCube.dimensions, nominalSplit.reference);
 
     const newSplits = new Splits({
       splits: List([
-        adjustColorSplit(nominalSplit, nominalDimension, series),
+        adjustColorSplit(nominalSplit, nominalDimension, series, appSettings.customization.visualizationColors),
         adjustContinuousTimeSplit(timeSplit)
       ])
     });

--- a/src/common/visualization-manifests/line-chart/line-chart.ts
+++ b/src/common/visualization-manifests/line-chart/line-chart.ts
@@ -81,7 +81,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
   })
 
   .when(Predicates.areExactSplitKinds("time", "*"))
-  .then(({ splits, series, dataCube }) => {
+  .then(({ splits, series, dataCube, appSettings }) => {
     const timeSplit = splits.getSplit(0);
 
     const newTimeSplit = timeSplit
@@ -91,7 +91,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
     const colorSplit = splits.getSplit(1);
     const colorDimension = findDimensionByName(dataCube.dimensions, colorSplit.reference);
 
-    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series);
+    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series, appSettings.customization.visualizationColors);
 
     return Resolve.automatic(8, {
       splits: new Splits({ splits: List([newColorSplit, newTimeSplit]) })
@@ -99,20 +99,20 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
   })
 
   .when(Predicates.areExactSplitKinds("*", "time"))
-  .then(({ splits, series, dataCube }) => {
+  .then(({ splits, series, dataCube, appSettings }) => {
     const timeSplit = splits.getSplit(1);
     const newTimeSplit = adjustContinuousTimeSplit(timeSplit);
 
     const colorSplit = splits.getSplit(0);
     const colorDimension = findDimensionByName(dataCube.dimensions, colorSplit.reference);
-    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series);
+    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series, appSettings.customization.visualizationColors);
 
     const newSplits = new Splits({ splits: List([newColorSplit, newTimeSplit]) });
     if (newSplits.equals(splits)) return Resolve.ready(10);
     return Resolve.automatic(8, { splits: newSplits });
   })
   .when(Predicates.areExactSplitKinds("*", "number"))
-  .then(({ splits, dataCube, series }) => {
+  .then(({ splits, dataCube, series, appSettings }) => {
     const numberSplit = splits.getSplit(1);
     const numberDimension = findDimensionByName(dataCube.dimensions, numberSplit.reference);
 
@@ -120,7 +120,7 @@ const rulesEvaluator = visualizationDependentEvaluatorBuilder
 
     const colorSplit = splits.getSplit(0);
     const colorDimension = findDimensionByName(dataCube.dimensions, colorSplit.reference);
-    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series);
+    const newColorSplit = adjustColorSplit(colorSplit, colorDimension, series, appSettings.customization.visualizationColors);
 
     const newSplits = new Splits({ splits: List([newColorSplit, newNumberSplit]) });
     if (newSplits.equals(splits)) return Resolve.ready(10);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -148,7 +148,7 @@ export default function createApp(serverSettings: ServerSettings, settingsManage
   attachRouter("/sources", sourcesRouter(settingsManager.sourcesGetter));
   attachRouter("/plywood", plywoodRouter(settingsManager));
   attachRouter("/plyql", plyqlRouter(settingsManager.sourcesGetter));
-  attachRouter("/mkurl", mkurlRouter(settingsManager.sourcesGetter));
+  attachRouter("/mkurl", mkurlRouter(settingsManager.appSettings, settingsManager.sourcesGetter));
   attachRouter("/shorten", shortenRouter(settingsManager.appSettings, isTrustedProxy));
 
   attachRouter("/", turniloRouter(settingsManager.appSettings, () => settingsManager.getTimekeeper(), version));

--- a/src/server/routes/mkurl/mkurl.mocha.ts
+++ b/src/server/routes/mkurl/mkurl.mocha.ts
@@ -19,6 +19,7 @@ import * as bodyParser from "body-parser";
 import express from "express";
 import { $ } from "plywood";
 import supertest from "supertest";
+import { appSettings } from "../../../common/models/app-settings/app-settings.fixtures";
 import { wikiSourcesWithExecutor } from "../../../common/models/sources/sources.fixtures";
 import { UrlHashConverterFixtures } from "../../../common/utils/url-hash-converter/url-hash-converter.fixtures";
 import { mkurlRouter } from "./mkurl";
@@ -29,7 +30,7 @@ const app = express();
 
 app.use(bodyParser.json());
 
-app.use(mkurlPath, mkurlRouter(() => Promise.resolve(wikiSourcesWithExecutor)));
+app.use(mkurlPath, mkurlRouter(appSettings, () => Promise.resolve(wikiSourcesWithExecutor)));
 
 describe("mkurl router", () => {
   it("gets a simple url back", (testComplete: any) => {

--- a/src/server/routes/mkurl/mkurl.ts
+++ b/src/server/routes/mkurl/mkurl.ts
@@ -16,6 +16,8 @@
  */
 
 import { Request, Response, Router } from "express";
+import { deserialize } from "../../../client/deserializers/app-settings";
+import { AppSettings, ClientAppSettings, serialize } from "../../../common/models/app-settings/app-settings";
 import { ClientDataCube } from "../../../common/models/data-cube/data-cube";
 import { isQueryable } from "../../../common/models/data-cube/queryable-data-cube";
 import { Essence } from "../../../common/models/essence/essence";
@@ -24,7 +26,11 @@ import { urlHashConverter } from "../../../common/utils/url-hash-converter/url-h
 import { definitionConverters, ViewDefinitionVersion } from "../../../common/view-definitions";
 import { SourcesGetter } from "../../utils/settings-manager/settings-manager";
 
-export function mkurlRouter(sourcesGetter: SourcesGetter) {
+function convertAppSettings(appSettings: AppSettings): ClientAppSettings {
+  return deserialize(serialize(appSettings));
+}
+
+export function mkurlRouter(appSettings: AppSettings, sourcesGetter: SourcesGetter) {
 
   const router = Router();
 
@@ -79,7 +85,7 @@ export function mkurlRouter(sourcesGetter: SourcesGetter) {
     };
 
     try {
-      essence = definitionConverter.fromViewDefinition(viewDefinition, clientDataCube);
+      essence = definitionConverter.fromViewDefinition(viewDefinition, clientDataCube, convertAppSettings(appSettings));
     } catch ({ message }) {
       res.status(400).send({ error: "invalid viewDefinition object", message });
       return;


### PR DESCRIPTION
- add context for customization settings
- example how to use settings context
- add visualizationColors to customization settings
- use colors from customization settings instead of hardcoded series
- attach appSettings object to Essence so it can be used during visualization resolving
