### PR TITLE
Initial dependabot and mergify configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+#
+#  Prototype for node ecosystem, needs to be configured
+#
+#  - package-ecosystem: "npm"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      # allow only production updates
+#      - dependency-name: "*"
+#        dependency-type: "production"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     secrets: inherit
 
   all-checks:
-    needs: [deploy, all-reports]
+    needs: [required-checks, deploy, all-reports]
     runs-on: ubuntu-latest
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,9 @@ jobs:
     needs: required-checks
     uses: ./.github/workflows/reports.yml
     secrets: inherit
+
+  all-checks:
+    needs: [deploy, all-reports]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     secrets: inherit
 
   all-checks:
-    needs: [required-checks, deploy, all-reports]
+    needs: [required-checks, deploy, reports]
     runs-on: ubuntu-latest
     steps:
       - run: exit 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'allegro/turnilo'
 
     env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/turnilo
+      IMAGE_NAME: eu.gcr.io/$GCP_PROJECT/turnilo
       TAG_NAME: ${{ github.head_ref || 'latest' }}
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ jobs:
     if: github.repository == 'allegro/turnilo'
 
     env:
-      IMAGE_NAME: eu.gcr.io/$GCP_PROJECT/turnilo
       TAG_NAME: ${{ github.head_ref || 'latest' }}
 
     steps:
@@ -23,6 +22,9 @@ jobs:
         uses: ./.github/actions/gcloud
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set Docker image name
+        run: echo "IMAGE_NAME=eu.gcr.io/$GCP_PROJECT/turnilo" >> $GITHUB_ENV
 
       - name: Configure Docker
         run: gcloud auth configure-docker --quiet

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -50,3 +50,9 @@ jobs:
               repo: context.repo.repo,
               body: ':stopwatch: Lighthouse [report](' + lighthouse_link + ')' 
             })
+
+  all-reports:
+    needs: [ size, lighthouse ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -50,9 +50,3 @@ jobs:
               repo: context.repo.repo,
               body: ':stopwatch: Lighthouse [report](' + lighthouse_link + ')' 
             })
-
-  all-reports:
-    needs: [ size, lighthouse ]
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -13,7 +13,6 @@ jobs:
     if: github.repository == 'allegro/turnilo'
 
     env:
-      IMAGE_NAME: eu.gcr.io/$GCP_PROJECT/turnilo
       TAG_NAME: ${{ github.head_ref }}
 
     steps:
@@ -24,6 +23,9 @@ jobs:
         uses: ./.github/actions/gcloud
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set Docker image name
+        run: echo "IMAGE_NAME=eu.gcr.io/$GCP_PROJECT/turnilo" >> $GITHUB_ENV
 
       - name: Undeploy app
         run: |

--- a/.github/workflows/undeploy.yml
+++ b/.github/workflows/undeploy.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'allegro/turnilo'
 
     env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/turnilo
+      IMAGE_NAME: eu.gcr.io/$GCP_PROJECT/turnilo
       TAG_NAME: ${{ github.head_ref }}
 
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,19 @@
+pull_request_rules:
+  - name: automatic merge for GitHub actions
+    conditions:
+      - author=dependabot[bot]
+      - check-success=all-checks # check all actions
+      - label=github-actions # label assigned by dependabot
+      - base=master
+    actions:
+      merge:
+        method: rebase
+  - name: automatic merge for Node dependencies
+    conditions:
+      - author=dependabot[bot]
+      - check-success=required-checks # check required actions only
+      - label=npm # label assigned by dependabot
+      - base=master
+    actions:
+      merge:
+        method: rebase

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
+; dependencies saved to package.json will be configured with an exact version rather than using npm's default semver range operator
 save-exact=true
+; stop 'npm install' from sending an audit report
+audit = false


### PR DESCRIPTION
Closes #958 

Bonus: get rid of GCP_PROJECT_ID secret, project id is set by google-github-actions/auth based on crendential json file.