### PR TITLE
sass-lint rules cleanup

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -42,11 +42,8 @@ rules:
   nesting-depth:
   - 2
   - max-depth: 4
-  no-attribute-selectors: 0
-  no-color-hex: 0
   no-color-keywords: 2
   no-color-literals: 0
-  no-combinators: 0
   no-css-comments: 0
   no-debug: 2
   no-disallowed-properties: 2
@@ -55,7 +52,6 @@ rules:
   - exclude:
     - src
   no-empty-rulesets: 2
-  no-extends: 0
   no-ids: 2
   no-important: 2
   no-invalid-hex: 2
@@ -65,7 +61,6 @@ rules:
   no-trailing-whitespace: 2
   no-trailing-zero: 0
   no-transition-all: 2
-  no-universal-selectors: 0
   no-url-protocols: 2
   no-vendor-prefixes:
   - 2
@@ -79,7 +74,6 @@ rules:
   property-units: 2
   pseudo-element: 2
   quotes: 2
-  shorthand-values: 0
   single-line-per-selector: 0
   space-after-bang: 2
   space-after-colon: 2

--- a/src/client/components/button-group/button-group.scss
+++ b/src/client/components/button-group/button-group.scss
@@ -40,7 +40,7 @@ $title-margin: 6px;
       flex: 2;
       text-align: center;
       height: $input-height;
-      padding: 8px 2px 0 2px;
+      padding: 8px 2px 0;
       border-right: 0;
 
       &:first-child {

--- a/src/client/components/date-range-picker/date-range-picker.scss
+++ b/src/client/components/date-range-picker/date-range-picker.scss
@@ -47,7 +47,7 @@
       .caret {
         position: absolute;
         top: 0;
-        padding: 3px 3px;
+        padding: 3px;
         cursor: pointer;
 
         svg {

--- a/src/client/components/pinboard-panel/pinboard-panel.scss
+++ b/src/client/components/pinboard-panel/pinboard-panel.scss
@@ -27,7 +27,7 @@
   flex-direction: column;
   flex-wrap: wrap;
 
-  padding: $tile-margin-v $tile-margin-h 0 $tile-margin-h;
+  padding: $tile-margin-v $tile-margin-h 0;
 
   .dimension-tile,
   .drop-indicator-tile {

--- a/src/client/components/tabular-scroller/corner/corner.scss
+++ b/src/client/components/tabular-scroller/corner/corner.scss
@@ -26,7 +26,7 @@
   width: calc(100% - #{$space-left});
   height: $header-height;
   overflow: hidden;
-  padding: $header-padding-top 0 0 0;
+  padding: $header-padding-top 0 0;
   margin-left: $space-left;
 
   .resize-handle {

--- a/src/client/components/tile-header/tile-header.scss
+++ b/src/client/components/tile-header/tile-header.scss
@@ -20,7 +20,7 @@
 .tile-header {
   .title {
     @include css-variable(color, text-standard);
-    padding: 15px $padding-compact 10px $padding-compact;
+    padding: 15px $padding-compact 10px;
     font-size: 12px;
     text-transform: uppercase;
     cursor: default;

--- a/src/client/modals/url-shortener-modal/url-shortener-modal.scss
+++ b/src/client/modals/url-shortener-modal/url-shortener-modal.scss
@@ -24,7 +24,7 @@
       display: flex;
 
       .short-url, .copy-button {
-        padding: 8px 8px 6px 8px;
+        padding: 8px 8px 6px;
         display: inline-block;
         border-radius: 0;
       }

--- a/src/client/views/cube-view/cube-header-bar/cube-header-bar.scss
+++ b/src/client/views/cube-view/cube-header-bar/cube-header-bar.scss
@@ -36,7 +36,7 @@
 
   .left-bar .cube-description {
     display: inline-block;
-    padding: 11px 5px 11px 5px;
+    padding: 11px 5px;
     margin-left: 5px;
     width: auto;
 

--- a/src/client/views/cube-view/cube-view.scss
+++ b/src/client/views/cube-view/cube-view.scss
@@ -97,7 +97,7 @@ $control-panel-height: 3 * $control-tile-height + 2px;
         }
 
         .series-tile-row {
-          border-radius: $corner 0 0 0;
+          border-radius: $corner 0 0;
         }
 
         .filter-tile-row {

--- a/src/client/views/home-view/data-cube-card/data-cube-card.scss
+++ b/src/client/views/home-view/data-cube-card/data-cube-card.scss
@@ -17,13 +17,13 @@
 @import '../../../imports';
 
 .data-cube-card {
-  padding: 5px 0 0 0;
+  padding: 5px 0 0;
 
   .inner-container {
     background-color: $white;
     box-shadow: 0 1px 1px 0 rgba($black, 0.1);
     width: 100%;
-    padding: 16px 16px;
+    padding: 16px;
     border-radius: $corner;
 
     white-space: nowrap;


### PR DESCRIPTION
shorthand examples:


```
/* top and bottom | left and right */
margin: 5% auto;

/* top | left and right | bottom */
margin: 1em auto 2em;

/* top | right | bottom | left */
margin: 2px 1em 0 auto;
```