### PR TITLE
First attempt to allow dependabot updates for almost all dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-name: "cypress"
-      - dependency-name: "plywood*"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/d3"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "@types/node"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "@types/webpack"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "axios"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "d3"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "plywood"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      - dependency-name: "react"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "react-dom"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "react-test-renderer"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "typescript"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "webpack"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
Let's try with updates for almost all dependencies. I defined a few ignore rules for problematic dependencies, perhaps there are many more. We'll see.

In general I defined lock on semver-major, but for `0.x.y` dependencies like plywood or axios I put also semver-minor as ignored update type. If you see a better way to manage ignores, let me know in the comment.

I was especially surprised when I tried to update @type/node to 16.x. I thought that it should be in sync with Node version but I was wrong. I got dozen of errors from the TS transpiler.