### PR TITLE
Docs on numerical sorting without bucketing

### DIFF
--- a/docs/configuration-datacubes.md
+++ b/docs/configuration-datacubes.md
@@ -194,6 +194,8 @@ Specify whether the dimension should be bucketed by default. If unspecified defa
 
 Specify a specific sort strategy for this dimension in visualizations. If unspecified defaults to best sort strategy based on the visualization.
 
+String dimension is sorted lexicographically, if an underlying Druid column is of a string type as well. However, if the Druid column type is long, it is sorted numerically in Turnilo - even for string dimensions (they should be castable to numeric ones). This is helpful, if you do not want value bucketing (which is turned on for numeric dimensions) and numerical sorting. 
+
 **kind** ("string" \| "boolean" \| "number" \| "time")
 
 Specify kind of data inside dimension. It defaults to "string".


### PR DESCRIPTION
A short trick description on how to avoid numeric dimension bucketing and allowing numerical sorting for a given dimension