### PR TITLE
Fix 4 default selected measures are properly selected when defaultSelectedMeasures is not specified

### DIFF
--- a/src/common/models/data-cube/data-cube.ts
+++ b/src/common/models/data-cube/data-cube.ts
@@ -513,7 +513,7 @@ export function getDefaultSplits(dataCube: ClientDataCube): Splits {
 }
 
 export function getDefaultSeries(dataCube: ClientDataCube): SeriesList {
-  if (dataCube.defaultSelectedMeasures) {
+  if (dataCube.defaultSelectedMeasures.length > 0) {
     return SeriesList.fromMeasures(dataCube.defaultSelectedMeasures.map(name => findMeasureByName(dataCube.measures, name)));
   }
   const first4Measures = allMeasures(dataCube.measures).slice(0, 4);


### PR DESCRIPTION
https://github.com/allegro/turnilo/issues/1108
Modify defaultSelectedMeasures to function as described in the [documentation](https://allegro.github.io/turnilo/configuration-datacubes.html#basic-data-cube-properties)
