### PR TITLE
bug fix. ExternalViews where not deserialized correctly on client side

### DIFF
--- a/src/client/deserializers/customization.ts
+++ b/src/client/deserializers/customization.ts
@@ -17,13 +17,14 @@
 import { Timezone } from "chronoshift";
 import { ClientCustomization, SerializedCustomization } from "../../common/models/customization/customization";
 import { deserialize as deserializeLocale } from "../../common/models/locale/locale";
+import { ExternalView } from "../../common/models/external-view/external-view";
 
 export function deserialize(customization: SerializedCustomization): ClientCustomization {
   const { headerBackground, messages, locale, customLogoSvg, timezones, externalViews, hasUrlShortener, sentryDSN, visualizationColors } = customization;
   return {
     headerBackground,
     customLogoSvg,
-    externalViews,
+    externalViews: externalViews.map(ExternalView.fromJS),
     hasUrlShortener,
     sentryDSN,
     messages,


### PR DESCRIPTION
If I define an externalView in the configuration file and then click on the share menu the following exception is thrown

```
Uncaught TypeError: externalView.linkGeneratorFn is not a function
    externalViewItems share-menu.tsx:115
    externalViewItems share-menu.tsx:112
    render share-menu.tsx:142
    React 11
    unstable_runWithPriority scheduler.development.js:653
    React 21
    unstable_runWithPriority scheduler.development.js:653
    React 6
    componentDidMount sources-provider.tsx:73
    promise callback*componentDidMount sources-provider.tsx:72
    React 6
    unstable_runWithPriority scheduler.development.js:653
    React 5
    unstable_runWithPriority scheduler.development.js:653
    React 7
    tsx main.tsx:67
    Webpack 6
share-menu.tsx:115:29
```
This patch seems to fix the issue.

Step to reproduce:
1. add the following lines to config-examples.yaml
```
externalViews:
   - title: Timezone Info
     linkGenerator: >
       { 
          return 'http://www.tickcounter.com/timezone/'; 
       }
```
2. start turnilo and click on the share menu. 