### PR TITLE
Fix NPA in line chart

### DIFF
--- a/src/common/visualization-manifests/line-chart/settings.ts
+++ b/src/common/visualization-manifests/line-chart/settings.ts
@@ -34,7 +34,7 @@ const createSettings = (settings: Partial<LineChartSettings>): ImmutableRecord<L
 
 export const settings: LineChartVisualizationSettings = {
   converter: {
-    print: (settings: ImmutableRecord<LineChartSettings>) => settings.toJS(),
+    print: (settings: ImmutableRecord<LineChartSettings>) => settings ? settings.toJS() : null,
     read: (input: LineChartSettings) => createSettings({ groupSeries: !!input.groupSeries })
   },
   defaults: createSettings({}) as ImmutableRecord<object>


### PR DESCRIPTION
This PR aims to fix an NPA in the `line-chart` when `defaultSplitDimensions` is set to a field with `kind = time`