### PR TITLE
Clicking on pinboard items and legend items copy their text content to the clipboard

### DIFF
--- a/src/client/components/copy-toast/copy-toast.tsx
+++ b/src/client/components/copy-toast/copy-toast.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2018 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+export interface CopyToastProps {
+  text: string;
+}
+
+export const CopyToast: React.FC<CopyToastProps> = ({text}) => {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: "0.5em",
+        left: "45%",
+        background: "var(--text-default-color)",
+        color: "var(--background-brand-text)",
+        padding: "8px 12px",
+        fontSize: "1em",
+        borderRadius: 3,
+        zIndex: 100,
+      }}
+    >
+      {`Copied '${text}'`}
+    </div>
+  );
+}

--- a/src/client/components/highlight-string/highlight-string.tsx
+++ b/src/client/components/highlight-string/highlight-string.tsx
@@ -18,6 +18,8 @@
 import React from "react";
 import { classNames } from "../../utils/dom/dom";
 import "./highlight-string.scss";
+import { getCopyHandlers, useCopyToClipboard } from "../../utils/copy-to-clipboard/copy-to-clipboard";
+import { CopyToast } from "../copy-toast/copy-toast";
 
 export interface HighlightStringProps {
   className?: string;
@@ -48,6 +50,28 @@ function highlightBy(text: string, highlight: string | RegExp): string | JSX.Ele
   return highlightByIndex(text, startIndex, startIndex + match[0].length);
 }
 
-export const HighlightString: React.FunctionComponent<HighlightStringProps> = ({ className, text, highlight }) => {
+export const HighlightString: React.FunctionComponent<HighlightStringProps> = ({ className, text, highlight}) => {
   return <span className={classNames("highlight-string", className)}>{highlightBy(text, highlight)}</span>;
+};
+
+export const CopyableHighlightString: React.FC<HighlightStringProps> = ({
+  className,
+  text,
+  highlight,
+}) => {
+  const { copy, copied } = useCopyToClipboard();
+  const copyProps =  getCopyHandlers(() => copy(text));
+  return (
+    <>
+      <span
+        className={classNames("highlight-string", className)}
+        title={`${text}: Copy to clipboard`}
+        {...copyProps}
+      >
+        {highlightBy(text, highlight)}
+      </span>
+
+      {copied && <CopyToast text={text}/>}
+    </>
+  );
 };

--- a/src/client/components/pinboard-tile/selectable-row.tsx
+++ b/src/client/components/pinboard-tile/selectable-row.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import { Unary } from "../../../common/utils/functional/functional";
 import { classNames } from "../../utils/dom/dom";
 import { Checkbox } from "../checkbox/checkbox";
-import { HighlightString } from "../highlight-string/highlight-string";
+import { CopyableHighlightString } from "../highlight-string/highlight-string";
 import "./selectable-row.scss";
 
 interface SelectableRowProps {
@@ -38,7 +38,11 @@ export const SelectableRow: React.FunctionComponent<SelectableRowProps> = props 
   >
     <div className="segment-value" title={strValue}>
       <Checkbox selected={selected} type="check" />
-      <HighlightString className="label" text={strValue} highlight={searchText} />
+      <CopyableHighlightString
+        className="label"
+        text={strValue}
+        highlight={searchText}
+        />
     </div>
     {measure && <div className="measure-value">{measure}</div>}
   </div>;

--- a/src/client/components/pinboard-tile/text-row.tsx
+++ b/src/client/components/pinboard-tile/text-row.tsx
@@ -17,7 +17,7 @@
 import React from "react";
 import { Unary } from "../../../common/utils/functional/functional";
 import { classNames } from "../../utils/dom/dom";
-import { HighlightString } from "../highlight-string/highlight-string";
+import { CopyableHighlightString } from "../highlight-string/highlight-string";
 import "./text-row.scss";
 
 interface TextRowProps {
@@ -35,7 +35,7 @@ export const TextRow: React.FunctionComponent<TextRowProps> = props => {
     className={classNames("pinboard-text-row", { selectable: clickable })}
     onClick={() => clickable && onClick(value)}>
     <div className="segment-value" title={strValue}>
-      <HighlightString className="label" text={strValue} highlight={searchText} />
+      <CopyableHighlightString className="label" text={strValue} highlight={searchText} />
     </div>
     {measure && <div className="measure-value">{measure}</div>}
   </div>;

--- a/src/client/utils/copy-to-clipboard/copy-to-clipboard.ts
+++ b/src/client/utils/copy-to-clipboard/copy-to-clipboard.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2016 Imply Data, Inc.
+ * Copyright 2017-2019 Allegro.pl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useCallback, useState } from "react";
+
+export function useCopyToClipboard(timeout = 1500) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), timeout);
+  }, [timeout]);
+
+  return { copy, copied };
+}export function getCopyHandlers(
+  onCopy: () => void
+): React.HTMLAttributes<HTMLElement> {
+  return {
+    onClick: onCopy,
+    style: { cursor: "copy" },
+  };
+}
+

--- a/src/client/visualizations/line-chart/legend/legend.tsx
+++ b/src/client/visualizations/line-chart/legend/legend.tsx
@@ -17,6 +17,8 @@
 import React from "react";
 import { useSettingsContext } from "../../../views/cube-view/settings-context";
 import "./legend.scss";
+import { getCopyHandlers, useCopyToClipboard } from "../../../utils/copy-to-clipboard/copy-to-clipboard";
+import { CopyToast } from "../../../components/copy-toast/copy-toast";
 
 export interface LegendProps {
   values: string[];
@@ -26,6 +28,23 @@ export interface LegendProps {
 interface LegendValuesProps {
   values: string[];
 }
+
+interface LegendValueProps {
+  text: string;
+}
+
+export const CopyableLegendItem: React.FC<LegendValueProps> = ({
+ text
+}) => {
+  const { copy, copied } = useCopyToClipboard();
+  const copyProps =  getCopyHandlers(() => copy(text));
+  return (
+    <>
+      <span className="legend-value-name" {...copyProps} >{text}</span>
+      {copied && <CopyToast text={text} />}
+    </>
+  );
+};
 
 const LegendValues: React.FunctionComponent<LegendValuesProps> = props => {
   const { customization: { visualizationColors } } = useSettingsContext();
@@ -40,7 +59,7 @@ const LegendValues: React.FunctionComponent<LegendValuesProps> = props => {
             <div className="legend-value-color" style={style} />
           </td>
           <td className="legend-value-label">
-            <span className="legend-value-name">{value}</span>
+            <CopyableLegendItem text={value} />
           </td>
         </tr>;
       })}


### PR DESCRIPTION
This allows users to quickly copy legend/pinboard values (that might be large enough to be ellided) into the navigator clipboard for further reuse.

> [!NOTE]
> This introduces a rudimentary toast system. While we could (and maybe should?) use something akin to react-toastify, I'd rather leave the decision to introduce new dependencies to app maintainers. As such, feel free to refactor/rewrite at will.

[Screen Recording 2026-01-31 at 10.55.15.webm](https://github.com/user-attachments/assets/88a7f941-ae2b-4be6-83f5-05dd0c91ef86)

Note that the cursors on legend items don't seem like they use the `copy` cursor, but that's only while screen recording. While navigating the app "normally", the cursor updates just fine.  

Closes [#1335](https://github.com/allegro/turnilo/issues/1135)